### PR TITLE
Messages db script change

### DIFF
--- a/database/script.sql
+++ b/database/script.sql
@@ -767,7 +767,7 @@ DROP TABLE IF EXISTS inbox;
 CREATE TABLE
     inbox (
         id VARCHAR(36) NOT NULL,
-        name TINYTEXT NOT NULL, -- Name of the group (only applicable if it's a group chat).
+        name TINYTEXT, -- Name of the group (only applicable if it's a group chat).
         is_group TINYINT (1) DEFAULT (0),
         create_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
         update_at DATETIME DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),

--- a/database/script.sql
+++ b/database/script.sql
@@ -766,7 +766,7 @@ DROP TABLE IF EXISTS inbox;
 
 CREATE TABLE
     inbox (
-        id VARCHAR(36) NOT NULL,
+        id BIGINT NOT NULL AUTO_INCREMENT,
         name TINYTEXT, -- Name of the group (only applicable if it's a group chat).
         is_group TINYINT (1) DEFAULT (0),
         create_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
@@ -781,7 +781,7 @@ DROP TABLE IF EXISTS inbox_member;
 
 CREATE TABLE
     inbox_member (
-        inbox_id VARCHAR(36) NOT NULL,
+        inbox_id BIGINT NOT NULL,
         user_id VARCHAR(36) NOT NULL,
         role ENUM ('ADMIN', 'MEMBER') NOT NULL,
         joined_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
@@ -798,7 +798,7 @@ DROP TABLE IF EXISTS message;
 CREATE TABLE
     message (
         id BIGINT NOT NULL AUTO_INCREMENT,
-        inbox_id VARCHAR(36) NOT NULL,
+        inbox_id BIGINT NOT NULL,
         sender_id VARCHAR(36) NOT NULL,
         content TEXT,
         message_type ENUM ('TEXT', 'IMAGE', 'FILE', 'VIDEO', 'SOUND') NOT NULL,

--- a/database/script.sql
+++ b/database/script.sql
@@ -767,13 +767,11 @@ DROP TABLE IF EXISTS inbox;
 CREATE TABLE
     inbox (
         id VARCHAR(36) NOT NULL,
-        name TINYTEXT NOT NULL,
-        typeof_inbox ENUM ('INDIVIDUAL', 'GROUP') NOT NULL,
-        last_message TEXT,
-        last_sent_user_id varchar(36),
+        name TINYTEXT NOT NULL, -- Name of the group (only applicable if it's a group chat).
+        is_group TINYINT (1) DEFAULT (0),
         create_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
+        update_at DATETIME DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
         is_delete TINYINT (1) DEFAULT (0),
-        FOREIGN KEY (last_sent_user_id) REFERENCES user (id),
         PRIMARY KEY (id)
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;
 
@@ -786,6 +784,7 @@ CREATE TABLE
         inbox_id VARCHAR(36) NOT NULL,
         user_id VARCHAR(36) NOT NULL,
         role ENUM ('ADMIN', 'MEMBER') NOT NULL,
+        joined_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
         is_delete TINYINT (1) DEFAULT (0),
         FOREIGN KEY (inbox_id) REFERENCES inbox (id),
         FOREIGN KEY (user_id) REFERENCES user (id),
@@ -798,33 +797,19 @@ DROP TABLE IF EXISTS message;
 
 CREATE TABLE
     message (
-        id VARCHAR(36) NOT NULL,
+        id BIGINT NOT NULL AUTO_INCREMENT,
         inbox_id VARCHAR(36) NOT NULL,
-        user_id VARCHAR(36) NOT NULL,
+        sender_id VARCHAR(36) NOT NULL,
         content TEXT,
-        typeof_mess ENUM ('TEXT', 'IMAGE', 'FILE', 'VIDEO', 'SOUND', 'ICON') NOT NULL,
-        children_id VARCHAR(36),
+        message_type ENUM ('TEXT', 'IMAGE', 'FILE', 'VIDEO', 'SOUND') NOT NULL,
+        parent_message_id BIGINT,
         create_at DATETIME DEFAULT CURRENT_TIMESTAMP(),
+        update_at DATETIME DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
         is_delete TINYINT (1) DEFAULT (0),
         FOREIGN KEY (inbox_id) REFERENCES inbox (id),
-        FOREIGN KEY (user_id) REFERENCES user (id),
-        FOREIGN KEY (children_id) REFERENCES message (id),
-        PRIMARY KEY (id, inbox_id, user_id)
-    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;
-
-BEGIN;
-
-DROP TABLE IF EXISTS message_access;
-
-CREATE TABLE
-    message_access (
-        mess_id VARCHAR(36) NOT NULL,
-        inbox_id VARCHAR(36) NOT NULL,
-        creator VARCHAR(36) NOT NULL,
-        user_id VARCHAR(36) NOT NULL,
-        FOREIGN KEY (mess_id, inbox_id, creator) REFERENCES message (id, inbox_id, user_id),
-        FOREIGN KEY (user_id) REFERENCES user (id),
-        PRIMARY KEY (mess_id, inbox_id, creator, user_id)
+        FOREIGN KEY (sender_id) REFERENCES user (id),
+        FOREIGN KEY (parent_message_id) REFERENCES message (id),
+        PRIMARY KEY (id)
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;
 
 BEGIN;


### PR DESCRIPTION
1. Bảng `inbox`
- Trường `id` thành BIGINT và AUTO_INCREMENT
- Thay `typeof_inbox` thành `is_group` để xác định xem có phải nhóm chat hay là 1-1
- Thêm trường `update_at`
- Xóa 2 trường `last_message` và `last_sent_user_id` vì dư thừa thông tin. Có 2 trường này đòi hỏi phải update liên tục
3. Bảng `inbox_member`
- Thêm trường `is_joined`
4. Bảng `message`
- Đổi id từ UUID sang BIGINT và AUTO_INCREMENT
- `user_id` sang `sender_id` để rõ ràng hơn
- `typeof_mess` thành `message_type`
- `children_id` thành `parent_id` sẽ hợp lý hơn vì khi rep một tin nhắn cần id của thằng cha thay vì thằng con
- Khóa chính chỉ còn là `id`
5. Bảng `message_access`
- Xóa bảng vì không cần thiết, có thể kiếm tra bằng cách check xem có phải là `inbox_member` của `inbox` đó hay ko 