### PR TITLE
CN Fix Push Notification for mobile and Solve duplicate token problem

### DIFF
--- a/counsel-service/src/main/java/hcmus/alumni/counsel/model/UserSubscriptionTokenId.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/model/UserSubscriptionTokenId.java
@@ -1,0 +1,21 @@
+package hcmus.alumni.counsel.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSubscriptionTokenId implements Serializable {
+	@Column(name = "user_id", length = 36, nullable = false)
+	private String userId;
+	
+	@Column(name = "token", length = 200, nullable = false)
+	private String token;
+}

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/model/UserSubscriptionTokenModel.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/model/UserSubscriptionTokenModel.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.EmbeddedId;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,21 +17,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class UserSubscriptionTokenModel implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
-	@Id
-	@Column(name = "id", length = 36, nullable = false)
-	private String id;
-	
-	@Column(name = "user_id", length = 36)
-	private String userId;
-	
-	@Column(name = "token", columnDefinition = "TEXT")
-	private String token;
-	
-	@Column(name = "device_name", length = 100)
-	private String deviceName;
+	@EmbeddedId
+	private UserSubscriptionTokenId id;
 	
 	@Column(name = "is_delete", columnDefinition = "TINYINT(1) DEFAULT(0)")
 	private Boolean isDelete = false;
+	
+	public UserSubscriptionTokenModel(String userId, String token) {
+		this.id = new UserSubscriptionTokenId(userId, token);
+	}
+	
+	public String getUserId() {
+		return this.id.getUserId();
+	}
+	public String getToken() {
+		return this.id.getToken();
+	}
 }

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/repository/UserSubscriptionTokenRepository.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/repository/UserSubscriptionTokenRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import hcmus.alumni.counsel.model.UserSubscriptionTokenId;
 import hcmus.alumni.counsel.model.UserSubscriptionTokenModel;
 
-public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, String> {
-	@Query("SELECT ust.token FROM UserSubscriptionTokenModel ust WHERE ust.userId = :userId AND ust.isDelete = false")
-	List<String> findAllTokensByUserId(@Param("userId") String userId);
+public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, UserSubscriptionTokenId> {
+	@Query("SELECT ust.id.token FROM UserSubscriptionTokenModel ust WHERE ust.id.userId = :userId AND ust.isDelete = false")
+    List<String> findAllTokensByUserId(@Param("userId") String userId);
 }

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/utils/FirebaseService.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/utils/FirebaseService.java
@@ -2,8 +2,7 @@ package hcmus.alumni.counsel.utils;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.Notification;
 
 import hcmus.alumni.counsel.model.notification.NotificationChangeModel;
 import hcmus.alumni.counsel.model.notification.NotificationModel;
@@ -45,8 +44,10 @@ public class FirebaseService {
 		if (!tokens.isEmpty()) {
 			for (String token : tokens) {
 				Message message = Message.builder()
-					.putData("title", "Alumverse")
-					.putData("body", payload.toString())
+					.setNotification(Notification.builder()
+				            .setTitle("Alumverse")
+				            .setBody(payload.toString())
+				            .build())
 					.setToken(token)
 					.build();
 				try {

--- a/database/script.sql
+++ b/database/script.sql
@@ -849,11 +849,10 @@ DROP TABLE IF EXISTS user_subscription_token;
 
 CREATE TABLE
     user_subscription_token (
-        id VARCHAR(36) NOT NULL,
         user_id VARCHAR(36) NOT NULL,
-        token TEXT NOT NULL,
+        token VARCHAR(200) NOT NULL,
         is_delete TINYINT (1) DEFAULT (0),
-        PRIMARY KEY (id),
+        PRIMARY KEY (user_id, token),
         FOREIGN KEY (user_id) REFERENCES user (id)
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;
 

--- a/event-service/src/main/java/hcmus/alumni/event/model/UserSubscriptionTokenId.java
+++ b/event-service/src/main/java/hcmus/alumni/event/model/UserSubscriptionTokenId.java
@@ -1,0 +1,21 @@
+package hcmus.alumni.event.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSubscriptionTokenId implements Serializable {
+	@Column(name = "user_id", length = 36, nullable = false)
+	private String userId;
+	
+	@Column(name = "token", length = 200, nullable = false)
+	private String token;
+}

--- a/event-service/src/main/java/hcmus/alumni/event/model/UserSubscriptionTokenModel.java
+++ b/event-service/src/main/java/hcmus/alumni/event/model/UserSubscriptionTokenModel.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.EmbeddedId;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,21 +17,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class UserSubscriptionTokenModel implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
-	@Id
-	@Column(name = "id", length = 36, nullable = false)
-	private String id;
-	
-	@Column(name = "user_id", length = 36)
-	private String userId;
-	
-	@Column(name = "token", columnDefinition = "TEXT")
-	private String token;
-	
-	@Column(name = "device_name", length = 100)
-	private String deviceName;
+	@EmbeddedId
+	private UserSubscriptionTokenId id;
 	
 	@Column(name = "is_delete", columnDefinition = "TINYINT(1) DEFAULT(0)")
 	private Boolean isDelete = false;
+	
+	public UserSubscriptionTokenModel(String userId, String token) {
+		this.id = new UserSubscriptionTokenId(userId, token);
+	}
+	
+	public String getUserId() {
+		return this.id.getUserId();
+	}
+	public String getToken() {
+		return this.id.getToken();
+	}
 }

--- a/event-service/src/main/java/hcmus/alumni/event/repository/UserSubscriptionTokenRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/UserSubscriptionTokenRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import hcmus.alumni.event.model.UserSubscriptionTokenId;
 import hcmus.alumni.event.model.UserSubscriptionTokenModel;
 
-public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, String> {
-	@Query("SELECT ust.token FROM UserSubscriptionTokenModel ust WHERE ust.userId = :userId AND ust.isDelete = false")
+public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, UserSubscriptionTokenId> {
+	@Query("SELECT ust.id.token FROM UserSubscriptionTokenModel ust WHERE ust.id.userId = :userId AND ust.isDelete = false")
     List<String> findAllTokensByUserId(@Param("userId") String userId);
 }

--- a/event-service/src/main/java/hcmus/alumni/event/utils/FirebaseService.java
+++ b/event-service/src/main/java/hcmus/alumni/event/utils/FirebaseService.java
@@ -2,8 +2,7 @@ package hcmus.alumni.event.utils;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.Notification;
 
 import hcmus.alumni.event.model.notification.NotificationChangeModel;
 import hcmus.alumni.event.model.notification.NotificationModel;
@@ -45,8 +44,10 @@ public class FirebaseService {
 		if (!tokens.isEmpty()) {
 			for (String token : tokens) {
 				Message message = Message.builder()
-					.putData("title", "Alumverse")
-					.putData("body", payload.toString())
+					.setNotification(Notification.builder()
+				            .setTitle("Alumverse")
+				            .setBody(payload.toString())
+				            .build())
 					.setToken(token)
 					.build();
 				try {

--- a/group-service/src/main/java/hcmus/alumni/group/model/UserSubscriptionTokenId.java
+++ b/group-service/src/main/java/hcmus/alumni/group/model/UserSubscriptionTokenId.java
@@ -1,0 +1,21 @@
+package hcmus.alumni.group.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSubscriptionTokenId implements Serializable {
+	@Column(name = "user_id", length = 36, nullable = false)
+	private String userId;
+	
+	@Column(name = "token", length = 200, nullable = false)
+	private String token;
+}

--- a/group-service/src/main/java/hcmus/alumni/group/model/UserSubscriptionTokenModel.java
+++ b/group-service/src/main/java/hcmus/alumni/group/model/UserSubscriptionTokenModel.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.EmbeddedId;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,21 +17,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class UserSubscriptionTokenModel implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
-	@Id
-	@Column(name = "id", length = 36, nullable = false)
-	private String id;
-	
-	@Column(name = "user_id", length = 36)
-	private String userId;
-	
-	@Column(name = "token", columnDefinition = "TEXT")
-	private String token;
-	
-	@Column(name = "device_name", length = 100)
-	private String deviceName;
+	@EmbeddedId
+	private UserSubscriptionTokenId id;
 	
 	@Column(name = "is_delete", columnDefinition = "TINYINT(1) DEFAULT(0)")
 	private Boolean isDelete = false;
+	
+	public UserSubscriptionTokenModel(String userId, String token) {
+		this.id = new UserSubscriptionTokenId(userId, token);
+	}
+	
+	public String getUserId() {
+		return this.id.getUserId();
+	}
+	public String getToken() {
+		return this.id.getToken();
+	}
 }

--- a/group-service/src/main/java/hcmus/alumni/group/repository/UserSubscriptionTokenRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/UserSubscriptionTokenRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import hcmus.alumni.group.model.UserSubscriptionTokenId;
 import hcmus.alumni.group.model.UserSubscriptionTokenModel;
 
-public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, String> {
-	@Query("SELECT ust.token FROM UserSubscriptionTokenModel ust WHERE ust.userId = :userId AND ust.isDelete = false")
-	List<String> findAllTokensByUserId(@Param("userId") String userId);
+public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, UserSubscriptionTokenId> {
+	@Query("SELECT ust.id.token FROM UserSubscriptionTokenModel ust WHERE ust.id.userId = :userId AND ust.isDelete = false")
+    List<String> findAllTokensByUserId(@Param("userId") String userId);
 }

--- a/group-service/src/main/java/hcmus/alumni/group/utils/FirebaseService.java
+++ b/group-service/src/main/java/hcmus/alumni/group/utils/FirebaseService.java
@@ -2,9 +2,7 @@ package hcmus.alumni.group.utils;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.BatchResponse;
-import com.google.firebase.messaging.SendResponse;
+import com.google.firebase.messaging.Notification;
 
 import hcmus.alumni.group.model.notification.NotificationChangeModel;
 import hcmus.alumni.group.model.notification.NotificationModel;
@@ -46,8 +44,10 @@ public class FirebaseService {
 		if (!tokens.isEmpty()) {
 			for (String token : tokens) {
 				Message message = Message.builder()
-					.putData("title", "Alumverse")
-					.putData("body", payload.toString())
+					.setNotification(Notification.builder()
+				            .setTitle("Alumverse")
+				            .setBody(payload.toString())
+				            .build())
 					.setToken(token)
 					.build();
 				try {

--- a/news-service/src/main/java/hcmus/alumni/news/model/UserSubscriptionTokenId.java
+++ b/news-service/src/main/java/hcmus/alumni/news/model/UserSubscriptionTokenId.java
@@ -1,0 +1,21 @@
+package hcmus.alumni.news.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSubscriptionTokenId implements Serializable {
+	@Column(name = "user_id", length = 36, nullable = false)
+	private String userId;
+	
+	@Column(name = "token", length = 200, nullable = false)
+	private String token;
+}

--- a/news-service/src/main/java/hcmus/alumni/news/model/UserSubscriptionTokenModel.java
+++ b/news-service/src/main/java/hcmus/alumni/news/model/UserSubscriptionTokenModel.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.EmbeddedId;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,21 +17,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class UserSubscriptionTokenModel implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
-	@Id
-	@Column(name = "id", length = 36, nullable = false)
-	private String id;
-	
-	@Column(name = "user_id", length = 36)
-	private String userId;
-	
-	@Column(name = "token", columnDefinition = "TEXT")
-	private String token;
-	
-	@Column(name = "device_name", length = 100)
-	private String deviceName;
+	@EmbeddedId
+	private UserSubscriptionTokenId id;
 	
 	@Column(name = "is_delete", columnDefinition = "TINYINT(1) DEFAULT(0)")
 	private Boolean isDelete = false;
+	
+	public UserSubscriptionTokenModel(String userId, String token) {
+		this.id = new UserSubscriptionTokenId(userId, token);
+	}
+	
+	public String getUserId() {
+		return this.id.getUserId();
+	}
+	public String getToken() {
+		return this.id.getToken();
+	}
 }

--- a/news-service/src/main/java/hcmus/alumni/news/repository/UserSubscriptionTokenRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/UserSubscriptionTokenRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import hcmus.alumni.news.model.UserSubscriptionTokenId;
 import hcmus.alumni.news.model.UserSubscriptionTokenModel;
 
-public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, String> {
-	@Query("SELECT ust.token FROM UserSubscriptionTokenModel ust WHERE ust.userId = :userId AND ust.isDelete = false")
-	List<String> findAllTokensByUserId(@Param("userId") String userId);
+public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, UserSubscriptionTokenId> {
+	@Query("SELECT ust.id.token FROM UserSubscriptionTokenModel ust WHERE ust.id.userId = :userId AND ust.isDelete = false")
+    List<String> findAllTokensByUserId(@Param("userId") String userId);
 }

--- a/news-service/src/main/java/hcmus/alumni/news/utils/FirebaseService.java
+++ b/news-service/src/main/java/hcmus/alumni/news/utils/FirebaseService.java
@@ -2,8 +2,7 @@ package hcmus.alumni.news.utils;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.Notification;
 
 import hcmus.alumni.news.model.notification.NotificationChangeModel;
 import hcmus.alumni.news.model.notification.NotificationModel;
@@ -45,8 +44,10 @@ public class FirebaseService {
 		if (!tokens.isEmpty()) {
 			for (String token : tokens) {
 				Message message = Message.builder()
-					.putData("title", "Alumverse")
-					.putData("body", payload.toString())
+					.setNotification(Notification.builder()
+				            .setTitle("Alumverse")
+				            .setBody(payload.toString())
+				            .build())
 					.setToken(token)
 					.build();
 				try {

--- a/notification-service/src/main/java/hcmus/alumni/notification/controller/NotificationServiceController.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/controller/NotificationServiceController.java
@@ -85,16 +85,17 @@ public class NotificationServiceController {
 	@PostMapping("/subscription")
     public ResponseEntity<String> addUserSubscriptionToken(
     		@RequestHeader("userId") String userId, 
-    		@RequestBody UserSubscriptionTokenModel userSubscriptionToken) {
-        UserSubscriptionTokenModel createdToken = new UserSubscriptionTokenModel(userSubscriptionToken, userId);
+    		@RequestBody Map<String, Object> userSubscriptionToken) {
+        UserSubscriptionTokenModel createdToken = new UserSubscriptionTokenModel(userId, (String) userSubscriptionToken.get("token"));
         userSubscriptionTokenRepository.save(createdToken);
-        return new ResponseEntity<>(createdToken.getId(), HttpStatus.CREATED);
+        return new ResponseEntity<>(null, HttpStatus.CREATED);
     }
 
-	@DeleteMapping("/subscription/{userSubscriptionTokenId}")
+	@DeleteMapping("/subscription")
     public ResponseEntity<Void> deleteUserSubscriptionToken(
-    		@PathVariable("userSubscriptionTokenId") String id) {
-    	userSubscriptionTokenRepository.deleteUserSubscriptionTokenById(id);
+    		@RequestHeader("userId") String userId, 
+    		@RequestBody Map<String, Object> userSubscriptionToken) {
+    	userSubscriptionTokenRepository.deleteUserSubscriptionToken(userId, (String) userSubscriptionToken.get("token"));
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/notification-service/src/main/java/hcmus/alumni/notification/dto/IUserSubscriptionTokenDto.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/dto/IUserSubscriptionTokenDto.java
@@ -1,6 +1,6 @@
 package hcmus.alumni.notification.dto;
 
 public interface IUserSubscriptionTokenDto {
-	String getId();
+	String getUserId();
 	String getToken();
 }

--- a/notification-service/src/main/java/hcmus/alumni/notification/model/user/UserSubscriptionTokenId.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/model/user/UserSubscriptionTokenId.java
@@ -1,0 +1,25 @@
+package hcmus.alumni.notification.model.user;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSubscriptionTokenId implements Serializable {
+	@Column(name = "user_id", length = 36, nullable = false)
+	private String userId;
+	
+	@Column(name = "token", length = 200, nullable = false)
+	private String token;
+}

--- a/notification-service/src/main/java/hcmus/alumni/notification/model/user/UserSubscriptionTokenModel.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/model/user/UserSubscriptionTokenModel.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.EmbeddedId;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,23 +19,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class UserSubscriptionTokenModel implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
-	@Id
-	@Column(name = "id", length = 36, nullable = false)
-	private String id = UUID.randomUUID().toString();
-	
-	@Column(name = "user_id", length = 36)
-	private String userId;
-	
-	@Column(name = "token", columnDefinition = "TEXT")
-	private String token;
+	@EmbeddedId
+	private UserSubscriptionTokenId id;
 	
 	@Column(name = "is_delete", columnDefinition = "TINYINT(1) DEFAULT(0)")
 	private Boolean isDelete = false;
 	
-	public UserSubscriptionTokenModel(UserSubscriptionTokenModel copy, String userId) {
-		this.userId = userId;
-		this.token = copy.token;
+	public UserSubscriptionTokenModel(String userId, String token) {
+		this.id = new UserSubscriptionTokenId(userId, token);
+	}
+	
+	public String getUserId() {
+		return this.id.getUserId();
+	}
+	public String getToken() {
+		return this.id.getToken();
 	}
 }

--- a/notification-service/src/main/java/hcmus/alumni/notification/repository/UserSubscriptionTokenRepository.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/repository/UserSubscriptionTokenRepository.java
@@ -10,13 +10,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.notification.dto.IUserSubscriptionTokenDto;
 import hcmus.alumni.notification.model.user.UserSubscriptionTokenModel;
+import hcmus.alumni.notification.model.user.UserSubscriptionTokenId;
 
-public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, String> {
-	@Query("SELECT token FROM UserSubscriptionTokenModel token WHERE token.userId = :userId AND token.isDelete = false")
+public interface UserSubscriptionTokenRepository extends JpaRepository<UserSubscriptionTokenModel, UserSubscriptionTokenId> {
+	@Query("SELECT token FROM UserSubscriptionTokenModel token WHERE token.id.userId = :userId AND token.isDelete = false")
 	List<IUserSubscriptionTokenDto> getUserSubscriptionTokenByUserId(String userId);
 	
 	@Transactional
 	@Modifying
-	@Query(value = "UPDATE UserSubscriptionTokenModel SET isDelete = true WHERE id = :id")
-	int deleteUserSubscriptionTokenById(String id);
+	@Query(value = "UPDATE UserSubscriptionTokenModel token SET token.isDelete = true WHERE token.id.userId = :userId AND token.id.token = :token")
+	int deleteUserSubscriptionToken(String userId, String token);
 }


### PR DESCRIPTION
1. Fix Push Notification for mobile
Push notification của Firebase có 2 loại: 1 là "Notification" message, cái còn lại là "Data" message và cũng là cái tui đã dùng. Cái Duy dùng thì chỉ nhận notification message nên tui chỉnh lại thành cái này.
2. Solve duplicate token problem
Lúc Duy test thì bị duplicate token trên cùng 1 user. Nên tui chỉnh primary key của bảng user_subscription_token thành userId với token. Kéo theo là chỉnh mấy cái liên quan trong service