### PR TITLE
CN Handle Delete notifications

### DIFF
--- a/counsel-service/src/main/java/hcmus/alumni/counsel/config/FirebaseConfig.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/config/FirebaseConfig.java
@@ -18,13 +18,17 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp initializeFirebase() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        return FirebaseApp.initializeApp(options);
+    	if (FirebaseApp.getApps().isEmpty()) {
+            // Initialize Firebase only if there are no existing apps
+            FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            return FirebaseApp.initializeApp(options);
+        } else {
+            // Firebase already initialized, return existing instance
+            return FirebaseApp.getInstance();
+        }
     }
 }
 

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/controller/CounselServiceController.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/controller/CounselServiceController.java
@@ -79,6 +79,7 @@ import hcmus.alumni.counsel.repository.notification.NotificationRepository;
 import hcmus.alumni.counsel.utils.ImageUtils;
 import hcmus.alumni.counsel.repository.UserRepository;
 import hcmus.alumni.counsel.utils.FirebaseService;
+import hcmus.alumni.counsel.utils.NotificationService;
 import hcmus.alumni.counsel.common.NotificationType;
 
 @RestController
@@ -114,6 +115,8 @@ public class CounselServiceController {
 	private ImageUtils imageUtils;
 	@Autowired
 	private FirebaseService firebaseService;
+	@Autowired
+	private NotificationService notificationService;
 
 	private final static int MAXIMUM_PAGES = 50;
 	private final static int MAXIMUM_TAGS = 5;
@@ -423,6 +426,11 @@ public class CounselServiceController {
 
 		postAdvise.setStatus(new StatusPostModel(4));
 		postAdviseRepository.save(postAdvise);
+		
+		List<String> entityIds = commentPostAdviseRepository.findByPostAdviseId(id);
+		entityIds.add(id);
+		notificationService.deleteNotificationsByEntityIds(entityIds);
+		
 		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}
 
@@ -631,6 +639,11 @@ public class CounselServiceController {
 				postAdviseRepository.commentCountIncrement(originalComment.getPostAdvise().getId(), -1);
 			}
 		}
+		
+		// Delete notifications for the comment and its children
+		List<String> allCommentIds = commentPostAdviseRepository.findByParentIds(allParentId);
+		allCommentIds.add(commentId);
+		notificationService.deleteNotificationsByEntityIds(allCommentIds);
 
 		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}
@@ -754,6 +767,11 @@ public class CounselServiceController {
 		InteractPostAdviseModel interactPostAdvise = optionalInteractPostAdvise.get();
 		interactPostAdvise.setIsDelete(true);
 		postAdviseRepository.reactionCountIncrement(id, -1);
+		
+		List<String> entityIds = new ArrayList<String>();
+		entityIds.add(id);
+		notificationService.deleteNotificationsByEntityIds(entityIds);
+		
 		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}
 

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/repository/CommentPostAdviseRepository.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/repository/CommentPostAdviseRepository.java
@@ -59,4 +59,10 @@ public interface CommentPostAdviseRepository extends JpaRepository<CommentPostAd
     @Modifying
     @Query("UPDATE CommentPostAdviseModel c SET c.childrenCommentNumber = c.childrenCommentNumber + :count WHERE c.id = :id")
     int commentCountIncrement(String id, @Param("count") Integer count);
+    
+	@Query("SELECT c.id FROM CommentPostAdviseModel c WHERE c.postAdvise.id = :postAdviseId")
+	List<String> findByPostAdviseId(@Param("postAdviseId") String postAdviseId);
+	
+	@Query("SELECT c.id FROM CommentPostAdviseModel c WHERE c.parentId IN :parentIds")
+	List<String> findByParentIds(List<String> parentIds);
 }

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationChangeRepository.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationChangeRepository.java
@@ -1,5 +1,7 @@
 package hcmus.alumni.counsel.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -7,11 +9,14 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.counsel.model.notification.NotificationChangeModel;
+import hcmus.alumni.counsel.model.notification.NotificationObjectModel;
 
 public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {
 	@Transactional
 	@Modifying
 	@Query("UPDATE NotificationChangeModel nc SET nc.actor.id = :actorId WHERE nc.notificationObject.id = :notificationObjectId")
 	void updateActorIdByNotificationObject(@Param("notificationObjectId") Long notificationObjectId, @Param("actorId") String actorId);
+	
+	List<NotificationChangeModel> findByNotificationObject(NotificationObjectModel notificationObject);
 }
 

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationObjectRepository.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationObjectRepository.java
@@ -1,5 +1,6 @@
 package hcmus.alumni.counsel.repository.notification;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,6 @@ import hcmus.alumni.counsel.model.notification.NotificationObjectModel;
 
 public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {
 	Optional<NotificationObjectModel> findByEntityTypeAndEntityId(EntityTypeModel entityType, String entityId);
+	
+	List<NotificationObjectModel> findByEntityIdIn(List<String> entityIds);
 }
-

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationRepository.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/repository/notification/NotificationRepository.java
@@ -1,5 +1,7 @@
 package hcmus.alumni.counsel.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -7,11 +9,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.counsel.model.notification.NotificationModel;
+import hcmus.alumni.counsel.model.notification.NotificationObjectModel;
 
 public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {
 	@Transactional
 	@Modifying
 	@Query("UPDATE NotificationModel n SET n.status.id = :statusId WHERE n.notificationObject.id = :notificationObjectId")
 	void updateStatusByNotificationObject(@Param("notificationObjectId") Long notificationObjectId, @Param("statusId") int statusId);
+	
+	List<NotificationModel> findByNotificationObject(NotificationObjectModel notificationObject);
 }
-

--- a/counsel-service/src/main/java/hcmus/alumni/counsel/utils/NotificationService.java
+++ b/counsel-service/src/main/java/hcmus/alumni/counsel/utils/NotificationService.java
@@ -1,0 +1,50 @@
+package hcmus.alumni.counsel.utils;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hcmus.alumni.counsel.model.notification.NotificationChangeModel;
+import hcmus.alumni.counsel.model.notification.NotificationModel;
+import hcmus.alumni.counsel.model.notification.NotificationObjectModel;
+import hcmus.alumni.counsel.model.notification.StatusNotificationModel;
+import hcmus.alumni.counsel.repository.notification.NotificationChangeRepository;
+import hcmus.alumni.counsel.repository.notification.NotificationObjectRepository;
+import hcmus.alumni.counsel.repository.notification.NotificationRepository;
+
+@Service
+public class NotificationService {
+	@Autowired
+	private NotificationObjectRepository notificationObjectRepository;
+	@Autowired
+	private NotificationRepository notificationRepository;
+	@Autowired
+	private NotificationChangeRepository notificationChangeRepository;
+	
+	@Transactional
+	public void deleteNotificationsByEntityIds(List<String> entityIds) {
+		List<NotificationObjectModel> notificationObjects = notificationObjectRepository.findByEntityIdIn(entityIds);
+		
+		for (NotificationObjectModel notificationObject : notificationObjects) {
+			// Update isDelete for NotificationObject
+			notificationObject.setIsDelete(true);
+			notificationObjectRepository.save(notificationObject);
+			
+			// Update isDelete for NotificationChange
+			List<NotificationChangeModel> notificationChanges = notificationChangeRepository.findByNotificationObject(notificationObject);
+			for (NotificationChangeModel notificationChange : notificationChanges) {
+				notificationChange.setIsDelete(true);
+				notificationChangeRepository.save(notificationChange);
+			}
+			
+			// Update status for Notification
+			List<NotificationModel> notifications = notificationRepository.findByNotificationObject(notificationObject);
+			for (NotificationModel notification : notifications) {
+				notification.setStatus(new StatusNotificationModel(3));
+				notificationRepository.save(notification);
+			}
+		}
+	}
+}

--- a/event-service/src/main/java/hcmus/alumni/event/config/FirebaseConfig.java
+++ b/event-service/src/main/java/hcmus/alumni/event/config/FirebaseConfig.java
@@ -18,13 +18,17 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp initializeFirebase() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        return FirebaseApp.initializeApp(options);
+    	if (FirebaseApp.getApps().isEmpty()) {
+            // Initialize Firebase only if there are no existing apps
+            FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            return FirebaseApp.initializeApp(options);
+        } else {
+            // Firebase already initialized, return existing instance
+            return FirebaseApp.getInstance();
+        }
     }
 }
 

--- a/event-service/src/main/java/hcmus/alumni/event/repository/CommentEventRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/CommentEventRepository.java
@@ -52,4 +52,10 @@ public interface CommentEventRepository extends JpaRepository<CommentEventModel,
 	@Modifying
 	@Query("UPDATE CommentEventModel c SET c.childrenCommentNumber = c.childrenCommentNumber + :count WHERE c.id = :id")
 	int commentCountIncrement(String id,@Param("count") Integer count);
+	
+	@Query("SELECT c.id FROM CommentEventModel c WHERE c.event.id = :eventId")
+	List<String> findByEventId(@Param("eventId") String eventId);
+	
+	@Query("SELECT c.id FROM CommentEventModel c WHERE c.parentId IN :parentIds")
+	List<String> findByParentIds(List<String> parentIds);
 }

--- a/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationChangeRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationChangeRepository.java
@@ -1,8 +1,12 @@
 package hcmus.alumni.event.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.event.model.notification.NotificationChangeModel;
+import hcmus.alumni.event.model.notification.NotificationObjectModel;
 
-public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {}
-
+public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {
+	List<NotificationChangeModel> findByNotificationObject(NotificationObjectModel notificationObject);
+}

--- a/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationObjectRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationObjectRepository.java
@@ -1,8 +1,11 @@
 package hcmus.alumni.event.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.event.model.notification.NotificationObjectModel;
 
-public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {}
-
+public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {
+	List<NotificationObjectModel> findByEntityIdIn(List<String> entityIds);
+}

--- a/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/notification/NotificationRepository.java
@@ -1,8 +1,12 @@
 package hcmus.alumni.event.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.event.model.notification.NotificationModel;
+import hcmus.alumni.event.model.notification.NotificationObjectModel;
 
-public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {}
-
+public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {
+	List<NotificationModel> findByNotificationObject(NotificationObjectModel notificationObject);
+}

--- a/event-service/src/main/java/hcmus/alumni/event/utils/NotificationService.java
+++ b/event-service/src/main/java/hcmus/alumni/event/utils/NotificationService.java
@@ -1,0 +1,50 @@
+package hcmus.alumni.event.utils;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hcmus.alumni.event.model.notification.NotificationChangeModel;
+import hcmus.alumni.event.model.notification.NotificationModel;
+import hcmus.alumni.event.model.notification.NotificationObjectModel;
+import hcmus.alumni.event.model.notification.StatusNotificationModel;
+import hcmus.alumni.event.repository.notification.NotificationChangeRepository;
+import hcmus.alumni.event.repository.notification.NotificationObjectRepository;
+import hcmus.alumni.event.repository.notification.NotificationRepository;
+
+@Service
+public class NotificationService {
+	@Autowired
+	private NotificationObjectRepository notificationObjectRepository;
+	@Autowired
+	private NotificationRepository notificationRepository;
+	@Autowired
+	private NotificationChangeRepository notificationChangeRepository;
+	
+	@Transactional
+	public void deleteNotificationsByEntityIds(List<String> entityIds) {
+		List<NotificationObjectModel> notificationObjects = notificationObjectRepository.findByEntityIdIn(entityIds);
+		
+		for (NotificationObjectModel notificationObject : notificationObjects) {
+			// Update isDelete for NotificationObject
+			notificationObject.setIsDelete(true);
+			notificationObjectRepository.save(notificationObject);
+			
+			// Update isDelete for NotificationChange
+			List<NotificationChangeModel> notificationChanges = notificationChangeRepository.findByNotificationObject(notificationObject);
+			for (NotificationChangeModel notificationChange : notificationChanges) {
+				notificationChange.setIsDelete(true);
+				notificationChangeRepository.save(notificationChange);
+			}
+			
+			// Update status for Notification
+			List<NotificationModel> notifications = notificationRepository.findByNotificationObject(notificationObject);
+			for (NotificationModel notification : notifications) {
+				notification.setStatus(new StatusNotificationModel(3));
+				notificationRepository.save(notification);
+			}
+		}
+	}
+}

--- a/group-service/src/main/java/hcmus/alumni/group/config/FirebaseConfig.java
+++ b/group-service/src/main/java/hcmus/alumni/group/config/FirebaseConfig.java
@@ -18,13 +18,17 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp initializeFirebase() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        return FirebaseApp.initializeApp(options);
+		if (FirebaseApp.getApps().isEmpty()) {
+		    // Initialize Firebase only if there are no existing apps
+		    FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
+		    FirebaseOptions options = FirebaseOptions.builder()
+		            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+		            .build();
+		    return FirebaseApp.initializeApp(options);
+		} else {
+		    // Firebase already initialized, return existing instance
+		    return FirebaseApp.getInstance();
+		}
     }
 }
 

--- a/group-service/src/main/java/hcmus/alumni/group/controller/GroupServiceController.java
+++ b/group-service/src/main/java/hcmus/alumni/group/controller/GroupServiceController.java
@@ -457,7 +457,6 @@ public class GroupServiceController {
 		List<String> entityIds = commentPostGroupRepository.findByGroupId(id);
 		entityIds.addAll(postGroupRepository.findByGroupId(id));
 		entityIds.add(id);
-		System.out.println(entityIds);
 		notificationService.deleteNotificationsByEntityIds(entityIds);
 
 	    return ResponseEntity.status(HttpStatus.OK).body("");

--- a/group-service/src/main/java/hcmus/alumni/group/repository/CommentPostGroupRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/CommentPostGroupRepository.java
@@ -59,4 +59,13 @@ public interface CommentPostGroupRepository extends JpaRepository<CommentPostGro
     @Modifying
     @Query("UPDATE CommentPostGroupModel c SET c.childrenCommentNumber = c.childrenCommentNumber + :count WHERE c.id = :id")
     int commentCountIncrement(String id, @Param("count") Integer count);
+    
+	@Query("SELECT c.id FROM CommentPostGroupModel c JOIN c.postGroup p WHERE p.groupId = :groupId")
+	List<String> findByGroupId(@Param("groupId") String groupId);
+	
+	@Query("SELECT c.id FROM CommentPostGroupModel c WHERE c.postGroup.id = :postGroupId")
+	List<String> findByPostGroupId(@Param("postGroupId") String postGroupId);
+	
+	@Query("SELECT c.id FROM CommentPostGroupModel c WHERE c.parentId IN :parentIds")
+	List<String> findByParentIds(List<String> parentIds);
 }

--- a/group-service/src/main/java/hcmus/alumni/group/repository/PostGroupRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/PostGroupRepository.java
@@ -74,4 +74,7 @@ public interface PostGroupRepository extends JpaRepository<PostGroupModel, Strin
 
 	@Query(value = "select allow_add_options from post_group where id = :postId", nativeQuery = true)
 	boolean isAllowAddOptions(String postId);
+	
+	@Query("SELECT p.id FROM PostGroupModel p WHERE p.groupId = :groupId")
+	List<String> findByGroupId(@Param("groupId") String groupId);
 }

--- a/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationChangeRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationChangeRepository.java
@@ -1,17 +1,28 @@
 package hcmus.alumni.group.repository.notification;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import hcmus.alumni.group.model.UserModel;
 import hcmus.alumni.group.model.notification.NotificationChangeModel;
+import hcmus.alumni.group.model.notification.NotificationObjectModel;
 
 public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {
 	@Transactional
 	@Modifying
 	@Query("UPDATE NotificationChangeModel nc SET nc.actor.id = :actorId WHERE nc.notificationObject.id = :notificationObjectId")
 	void updateActorIdByNotificationObject(@Param("notificationObjectId") Long notificationObjectId, @Param("actorId") String actorId);
+	
+	List<NotificationChangeModel> findByNotificationObject(NotificationObjectModel notificationObject);
+	
+	@Query("SELECT nc FROM NotificationChangeModel nc JOIN nc.notificationObject no " +
+			"WHERE no.entityId = :entityId AND nc.actor.id = :actorId")
+	Optional<NotificationChangeModel> findByEntityIdAndActorId(String entityId, String actorId);
 }
 

--- a/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationObjectRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationObjectRepository.java
@@ -1,5 +1,6 @@
 package hcmus.alumni.group.repository.notification;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,9 @@ import hcmus.alumni.group.model.notification.NotificationObjectModel;
 
 public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {
 	Optional<NotificationObjectModel> findByEntityTypeAndEntityId(EntityTypeModel entityType, String entityId);
+	
+	List<NotificationObjectModel> findByEntityId(String entityId);
+	
+	List<NotificationObjectModel> findByEntityIdIn(List<String> entityIds);
 }
 

--- a/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationRepository.java
+++ b/group-service/src/main/java/hcmus/alumni/group/repository/notification/NotificationRepository.java
@@ -1,5 +1,7 @@
 package hcmus.alumni.group.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -7,11 +9,14 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.group.model.notification.NotificationModel;
+import hcmus.alumni.group.model.notification.NotificationObjectModel;
 
 public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {
 	@Transactional
 	@Modifying
 	@Query("UPDATE NotificationModel n SET n.status.id = :statusId WHERE n.notificationObject.id = :notificationObjectId")
 	void updateStatusByNotificationObject(@Param("notificationObjectId") Long notificationObjectId, @Param("statusId") int statusId);
+	
+	List<NotificationModel> findByNotificationObject(NotificationObjectModel notificationObject);
 }
 

--- a/group-service/src/main/java/hcmus/alumni/group/utils/NotificationService.java
+++ b/group-service/src/main/java/hcmus/alumni/group/utils/NotificationService.java
@@ -1,0 +1,73 @@
+package hcmus.alumni.group.utils;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hcmus.alumni.group.model.notification.NotificationChangeModel;
+import hcmus.alumni.group.model.notification.NotificationModel;
+import hcmus.alumni.group.model.notification.NotificationObjectModel;
+import hcmus.alumni.group.model.notification.StatusNotificationModel;
+import hcmus.alumni.group.repository.notification.NotificationChangeRepository;
+import hcmus.alumni.group.repository.notification.NotificationObjectRepository;
+import hcmus.alumni.group.repository.notification.NotificationRepository;
+
+@Service
+public class NotificationService {
+	@Autowired
+	private NotificationObjectRepository notificationObjectRepository;
+	@Autowired
+	private NotificationRepository notificationRepository;
+	@Autowired
+	private NotificationChangeRepository notificationChangeRepository;
+	
+	@Transactional
+	public void deleteNotificationsByEntityIds(List<String> entityIds) {
+		List<NotificationObjectModel> notificationObjects = notificationObjectRepository.findByEntityIdIn(entityIds);
+		
+		for (NotificationObjectModel notificationObject : notificationObjects) {
+			// Update isDelete for NotificationObject
+			notificationObject.setIsDelete(true);
+			notificationObjectRepository.save(notificationObject);
+			
+			// Update isDelete for NotificationChange
+			List<NotificationChangeModel> notificationChanges = notificationChangeRepository.findByNotificationObject(notificationObject);
+			for (NotificationChangeModel notificationChange : notificationChanges) {
+				notificationChange.setIsDelete(true);
+				notificationChangeRepository.save(notificationChange);
+			}
+			
+			// Update status for Notification
+			List<NotificationModel> notifications = notificationRepository.findByNotificationObject(notificationObject);
+			for (NotificationModel notification : notifications) {
+				notification.setStatus(new StatusNotificationModel(3));
+				notificationRepository.save(notification);
+			}
+		}
+	}
+	
+	@Transactional
+	public void deleteRequestJoinNotifications(String groupId, String requestUserId) {
+		Optional<NotificationChangeModel> optionalNotificationChange = notificationChangeRepository.findByEntityIdAndActorId(groupId, requestUserId);
+		
+		// Update isDelete for NotificationChange
+		NotificationChangeModel notificationChange = optionalNotificationChange.get();
+		notificationChange.setIsDelete(true);
+		notificationChangeRepository.save(notificationChange);
+		
+		// Update isDelete for NotificationObject
+		NotificationObjectModel notificationObject = notificationChange.getNotificationObject();
+		notificationObject.setIsDelete(true);
+		notificationObjectRepository.save(notificationObject);
+		
+		// Update status for Notification
+		List<NotificationModel> notifications = notificationRepository.findByNotificationObject(notificationObject);
+		for (NotificationModel notification : notifications) {
+			notification.setStatus(new StatusNotificationModel(3));
+			notificationRepository.save(notification);
+		}
+	}
+}

--- a/news-service/src/main/java/hcmus/alumni/news/config/FirebaseConfig.java
+++ b/news-service/src/main/java/hcmus/alumni/news/config/FirebaseConfig.java
@@ -18,13 +18,17 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp initializeFirebase() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        return FirebaseApp.initializeApp(options);
+        if (FirebaseApp.getApps().isEmpty()) {
+            // Initialize Firebase only if there are no existing apps
+            FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            return FirebaseApp.initializeApp(options);
+        } else {
+            // Firebase already initialized, return existing instance
+            return FirebaseApp.getInstance();
+        }
     }
 }
 

--- a/news-service/src/main/java/hcmus/alumni/news/repository/CommentNewsRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/CommentNewsRepository.java
@@ -53,4 +53,10 @@ public interface CommentNewsRepository extends JpaRepository<CommentNewsModel, S
     @Modifying
     @Query("UPDATE CommentNewsModel c SET c.childrenCommentNumber = c.childrenCommentNumber + :count WHERE c.id = :id")
     int commentCountIncrement(String id, @Param("count") Integer count);
+    
+    @Query("SELECT c.id FROM CommentNewsModel c WHERE c.news.id = :newsId")
+    List<String> findByNewsId(@Param("newsId") String newsId);
+    
+    @Query("SELECT c.id FROM CommentNewsModel c WHERE c.parentId IN :parentIds")
+    List<String> findByParentIds(List<String> parentIds);
 }

--- a/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationChangeRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationChangeRepository.java
@@ -1,8 +1,13 @@
 package hcmus.alumni.news.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.news.model.notification.NotificationChangeModel;
+import hcmus.alumni.news.model.notification.NotificationObjectModel;
 
-public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {}
+public interface NotificationChangeRepository extends JpaRepository<NotificationChangeModel, Long> {
+	List<NotificationChangeModel> findByNotificationObject(NotificationObjectModel notificationObject);
+}
 

--- a/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationObjectRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationObjectRepository.java
@@ -1,8 +1,12 @@
 package hcmus.alumni.news.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.news.model.notification.NotificationObjectModel;
 
-public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {}
+public interface NotificationObjectRepository extends JpaRepository<NotificationObjectModel, Long> {
+	List<NotificationObjectModel> findByEntityIdIn(List<String> entityIds);
+}
 

--- a/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/notification/NotificationRepository.java
@@ -1,8 +1,13 @@
 package hcmus.alumni.news.repository.notification;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hcmus.alumni.news.model.notification.NotificationModel;
+import hcmus.alumni.news.model.notification.NotificationObjectModel;
 
-public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {}
+public interface NotificationRepository extends JpaRepository<NotificationModel, Long> {
+	List<NotificationModel> findByNotificationObject(NotificationObjectModel notificationObject);
+}
 

--- a/news-service/src/main/java/hcmus/alumni/news/utils/NotificationService.java
+++ b/news-service/src/main/java/hcmus/alumni/news/utils/NotificationService.java
@@ -1,0 +1,50 @@
+package hcmus.alumni.news.utils;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hcmus.alumni.news.model.notification.NotificationChangeModel;
+import hcmus.alumni.news.model.notification.NotificationModel;
+import hcmus.alumni.news.model.notification.NotificationObjectModel;
+import hcmus.alumni.news.model.notification.StatusNotificationModel;
+import hcmus.alumni.news.repository.notification.NotificationChangeRepository;
+import hcmus.alumni.news.repository.notification.NotificationObjectRepository;
+import hcmus.alumni.news.repository.notification.NotificationRepository;
+
+@Service
+public class NotificationService {
+	@Autowired
+	private NotificationObjectRepository notificationObjectRepository;
+	@Autowired
+	private NotificationRepository notificationRepository;
+	@Autowired
+	private NotificationChangeRepository notificationChangeRepository;
+	
+	@Transactional
+	public void deleteNotificationsByEntityIds(List<String> entityIds) {
+		List<NotificationObjectModel> notificationObjects = notificationObjectRepository.findByEntityIdIn(entityIds);
+		
+		for (NotificationObjectModel notificationObject : notificationObjects) {
+			// Update isDelete for NotificationObject
+			notificationObject.setIsDelete(true);
+			notificationObjectRepository.save(notificationObject);
+			
+			// Update isDelete for NotificationChange
+			List<NotificationChangeModel> notificationChanges = notificationChangeRepository.findByNotificationObject(notificationObject);
+			for (NotificationChangeModel notificationChange : notificationChanges) {
+				notificationChange.setIsDelete(true);
+				notificationChangeRepository.save(notificationChange);
+			}
+			
+			// Update status for Notification
+			List<NotificationModel> notifications = notificationRepository.findByNotificationObject(notificationObject);
+			for (NotificationModel notification : notifications) {
+				notification.setStatus(new StatusNotificationModel(3));
+				notificationRepository.save(notification);
+			}
+		}
+	}
+}

--- a/notification-service/src/main/java/hcmus/alumni/notification/controller/NotificationServiceController.java
+++ b/notification-service/src/main/java/hcmus/alumni/notification/controller/NotificationServiceController.java
@@ -205,7 +205,8 @@ public class NotificationServiceController {
 				}
 			}
 	    }
-
+		
+		result.put("totalPages", notificationsPages.getTotalPages());
 		result.put("totalUnreadNotification", totalUnreadNotification);
 		result.put("notifications", notifications.stream().map(n -> mapper.map(n, NotificationDto.class)).toList());
 		


### PR DESCRIPTION
1. News service
Delete related notification when deleting news/comments 
2. Event service
Delete related notification when deleting events/comments 
3. Counsel service
Delete related notification when deleting posts advise/comments/reacts
4. Group service
Delete related notification when deleting groups/posts group/comments/reacts or approving/denying requests join group