### PR TITLE
Adjust APIs

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -18,4 +18,4 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 COPY --from=builder app/target/api-gateway.jar /app/
 # Command to run the Java application
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/api-gateway.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/api-gateway.jar"]

--- a/api-gateway/src/main/java/hcmus/alumni/apigateway/utils/JwtUtils.java
+++ b/api-gateway/src/main/java/hcmus/alumni/apigateway/utils/JwtUtils.java
@@ -1,6 +1,8 @@
 package hcmus.alumni.apigateway.utils;
 
 import java.security.Key;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -12,32 +14,32 @@ import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtUtils {
-	public static final String SECRET = "givepraiseforhehasnoequalworshiphimagodhasbeenbornuntotheworldcowerinfearhewillnotforgiveanyvicedevoteyourselfyourfateisoverwritten";
+	@Value("${jwt.secret}")
+	private String SECRET;
 
-	
 	public boolean validateToken(final String token) {
 		Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
-        try {
-        	Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
-            return true;
-        } catch (MalformedJwtException ex) {
-            System.err.println("Invalid JWT token");
-        } catch (ExpiredJwtException ex) {
-        	System.err.println("Expired JWT token");
-        } catch (UnsupportedJwtException ex) {
-        	System.err.println("Unsupported JWT token");
-        } catch (IllegalArgumentException ex) {
-        	System.err.println("JWT claims string is empty.");
-        }
-        return false;
+		try {
+			Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
+			return true;
+		} catch (MalformedJwtException ex) {
+			System.err.println("Invalid JWT token");
+		} catch (ExpiredJwtException ex) {
+			System.err.println("Expired JWT token");
+		} catch (UnsupportedJwtException ex) {
+			System.err.println("Unsupported JWT token");
+		} catch (IllegalArgumentException ex) {
+			System.err.println("JWT claims string is empty.");
+		}
+		return false;
 	}
 
 	private Key getSignKey() {
 		byte[] keyBytes = Decoders.BASE64.decode(SECRET);
 		return Keys.hmacShaKeyFor(keyBytes);
 	}
-	
+
 	public Claims getAllClaimsFromToken(String token) {
-        return Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token).getBody();
+		return Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token).getBody();
 	}
 }

--- a/api-gateway/src/main/java/hcmus/alumni/apigateway/utils/JwtUtils.java
+++ b/api-gateway/src/main/java/hcmus/alumni/apigateway/utils/JwtUtils.java
@@ -18,7 +18,6 @@ public class JwtUtils {
 	private String SECRET;
 
 	public boolean validateToken(final String token) {
-		Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
 		try {
 			Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
 			return true;

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+jwt.secret=${JWT_SECRET:givepraiseforhehasnoequalworshiphimagodhasbeenbornuntotheworldcowerinfearhewillnotforgiveanyvicedevoteyourselfyourfateisoverwritten}

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /app
 COPY --from=builder app/target/auth-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/auth-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/auth-service.jar"]

--- a/counsel-service/Dockerfile
+++ b/counsel-service/Dockerfile
@@ -24,4 +24,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/counsel-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/counsel-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/counsel-service.jar"]

--- a/database/02-data.sql
+++ b/database/02-data.sql
@@ -390,7 +390,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `role` WRITE;
 /*!40000 ALTER TABLE `role` DISABLE KEYS */;
-INSERT INTO `role` VALUES (1,'Admin',NULL,'2024-07-09 22:31:08','2024-07-09 22:31:08',0),(2,'FacultyManager',NULL,'2024-07-09 22:31:08','2024-07-09 22:31:08',0),(3,'Lecturer',NULL,'2024-07-09 22:31:08','2024-07-09 22:31:08',0),(4,'Alumni',NULL,'2024-07-09 22:31:08','2024-07-09 22:31:08',0),(5,'Guest',NULL,'2024-07-09 22:31:08','2024-07-09 22:31:08',0);
+INSERT INTO `role` VALUES (1,'Admin','Quản trị viên hệ thống','2024-07-09 22:31:08','2024-07-09 22:31:08',0),(2,'FacultyManager','Quản trị viên cấp khoa','2024-07-09 22:31:08','2024-07-09 22:31:08',0),(3,'Lecturer','Giảng viên','2024-07-09 22:31:08','2024-07-09 22:31:08',0),(4,'VerifiedAlumni','Cựu sinh viên đã xác thực','2024-07-09 22:31:08','2024-07-09 22:31:08',0),(5,'UnverifiedAlumni','Cựu sinh viên chưa xác thực','2024-07-09 22:31:08','2024-07-09 22:31:08',0);
 /*!40000 ALTER TABLE `role` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - EUREKA_URL=http://eureka:8761
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -61,7 +61,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -82,7 +82,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -103,7 +103,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -124,7 +124,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -145,7 +145,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -166,7 +166,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -187,7 +187,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar
@@ -208,7 +208,7 @@ services:
       - DB_CONNECTION_URL=jdbc:mysql://mysql:3306/alumverse_hcmus
     command: >
       java
-      -Xmx200M
+      -Xmx150M
       -Xms100M
       -XX:+UseContainerSupport
       -jar

--- a/event-service/Dockerfile
+++ b/event-service/Dockerfile
@@ -24,4 +24,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/event-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/event-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/event-service.jar"]

--- a/event-service/src/main/java/hcmus/alumni/event/common/FetchEventMode.java
+++ b/event-service/src/main/java/hcmus/alumni/event/common/FetchEventMode.java
@@ -1,0 +1,5 @@
+package hcmus.alumni.event.common;
+
+public enum FetchEventMode {
+    NORMAL, MANAGEMENT
+}

--- a/event-service/src/main/java/hcmus/alumni/event/config/StringToEnumConverter.java
+++ b/event-service/src/main/java/hcmus/alumni/event/config/StringToEnumConverter.java
@@ -1,0 +1,16 @@
+package hcmus.alumni.event.config;
+
+import org.springframework.core.convert.converter.Converter;
+
+import hcmus.alumni.event.common.FetchEventMode;
+
+public class StringToEnumConverter implements Converter<String, FetchEventMode> {
+    @Override
+    public FetchEventMode convert(String source) {
+        try {
+            return FetchEventMode.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return FetchEventMode.NORMAL;
+        }
+    }
+}

--- a/event-service/src/main/java/hcmus/alumni/event/config/WebConfig.java
+++ b/event-service/src/main/java/hcmus/alumni/event/config/WebConfig.java
@@ -1,0 +1,13 @@
+package hcmus.alumni.event.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToEnumConverter());
+    }
+}

--- a/event-service/src/main/java/hcmus/alumni/event/controller/EventServiceController.java
+++ b/event-service/src/main/java/hcmus/alumni/event/controller/EventServiceController.java
@@ -43,6 +43,7 @@ import org.springframework.web.multipart.MultipartFile;
 import hcmus.alumni.event.dto.CommentEventDto;
 import hcmus.alumni.event.dto.ICommentEventDto;
 import hcmus.alumni.event.dto.IEventDto;
+import hcmus.alumni.event.dto.IEventListDto;
 import hcmus.alumni.event.dto.IParticipantEventDto;
 import hcmus.alumni.event.model.EventModel;
 import hcmus.alumni.event.model.StatusPostModel;
@@ -125,6 +126,9 @@ public class EventServiceController {
 	    if (pageSize <= 0 || pageSize > MAXIMUM_PAGES) {
 	    	pageSize = MAXIMUM_PAGES;
 	    }
+		if (title.isBlank()) {
+			title = null;
+		}
 	    HashMap<String, Object> result = new HashMap<>();
 	    if (tagNames != null) {
 			for (int i = 0; i < tagNames.size(); i++) {
@@ -134,7 +138,7 @@ public class EventServiceController {
 
 	    try {
 	        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(order), orderBy));
-	        Page<IEventDto> events = null;
+	        Page<IEventListDto> events = null;
 	        
 	        Calendar cal = Calendar.getInstance();
 	        Date startDate = cal.getTime();
@@ -366,7 +370,7 @@ public class EventServiceController {
 	    Date startDate = cal.getTime();
 
 	    Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "participants"));
-	    Page<IEventDto> events = eventRepository.getHotEvents(userId, startDate, pageable);
+	    Page<IEventListDto> events = eventRepository.getHotEvents(userId, startDate, pageable);
 
 	    HashMap<String, Object> result = new HashMap<>();
 	    result.put("events", events.getContent());
@@ -389,7 +393,7 @@ public class EventServiceController {
 	    Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.DESC, "organizationTime"));
 	    Calendar cal = Calendar.getInstance();
         Date startDate = cal.getTime();
-        Page<IEventDto> events = eventRepository.getUserParticipatedEvents(requestingUserId, requestedUserId, startDate, mode, pageable);
+        Page<IEventListDto> events = eventRepository.getUserParticipatedEvents(requestingUserId, requestedUserId, startDate, mode, pageable);
 
         result.put("totalPages", events.getTotalPages());
         result.put("events", events.getContent());

--- a/event-service/src/main/java/hcmus/alumni/event/controller/EventServiceController.java
+++ b/event-service/src/main/java/hcmus/alumni/event/controller/EventServiceController.java
@@ -150,10 +150,7 @@ public class EventServiceController {
 			if (fetchMode.equals(FetchEventMode.MANAGEMENT)) {
 				// Check if is Admin or FacultyManager
 				Set<Integer> roleIds = userRepository.getRoleIds(userId);
-				if (roleIds.contains(ADMIN_ROLE_ID)) {
-					events = eventRepository.searchEvents(userId, title, statusId, null, tagNames, startDate, mode,
-							pageable);
-				} else if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
+				if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
 					events = eventRepository.searchEventsByUserFaculty(userId, title, statusId, tagNames,
 							startDate, mode, pageable);
 				}

--- a/event-service/src/main/java/hcmus/alumni/event/dto/IEventListDto.java
+++ b/event-service/src/main/java/hcmus/alumni/event/dto/IEventListDto.java
@@ -1,0 +1,41 @@
+package hcmus.alumni.event.dto;
+
+import java.util.Date;
+import java.util.Set;
+
+public interface IEventListDto {
+	interface User{
+		String getId();
+		String getFullName();
+		String getAvatarUrl();
+	}
+	interface StatusPost{
+		String getName();
+	}
+	interface Tag{
+		Integer getId();
+		String getName();
+	}
+	interface Faculty{
+		Integer getId();
+		String getName();
+	}
+
+	String getId();
+	String getTitle();
+	String getThumbnail();
+	String getOrganizationLocation();
+	Date getOrganizationTime();
+	Integer getViews();
+	Date getUpdateAt();
+	Date getPublishedAt();
+	User getCreator();
+	Set<Tag> getTags();
+	Faculty getFaculty();
+	StatusPost getStatus();
+	Integer getParticipants();
+	Integer getMinimumParticipants();
+	Integer getMaximumParticipants();
+	Integer getChildrenCommentNumber();
+	boolean getIsParticipated();
+}

--- a/event-service/src/main/java/hcmus/alumni/event/model/EventModel.java
+++ b/event-service/src/main/java/hcmus/alumni/event/model/EventModel.java
@@ -22,6 +22,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -29,11 +30,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class EventModel implements Serializable {
 	private static final long serialVersionUID = 1L;
 	
 	@Id
 	@Column(name = "id", length = 36, nullable = false)
+	@EqualsAndHashCode.Include
 	private String id;
 	
 	@ManyToOne

--- a/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
@@ -23,39 +23,6 @@ public interface EventRepository extends JpaRepository<EventModel, String> {
 			"where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
 	List<String> getPermissions(String userId, String domain);
 
-	// @Query(value = "SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
-	// 		"FROM EventModel e " +
-	// 		"LEFT JOIN e.status s " +
-	// 		"LEFT JOIN e.faculty f " +
-	// 		"LEFT JOIN e.tags t " +
-	// 		"LEFT JOIN ParticipantEventModel p " +
-	// 		"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
-	// 		"WHERE (:statusId IS NULL OR s.id = :statusId) " +
-	// 		"AND (:facultyId IS NULL OR f.id = :facultyId) " +
-	// 		"AND (:title IS NULL OR e.title LIKE %:title%) " +
-	// 		"AND (CASE " +
-	// 		"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
-	// 		"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
-	// 		"       ELSE true " +
-	// 		"   END) " +
-	// 		"AND s.id != 4 " +
-	// 		"AND (:tagNames IS NULL OR t.name IN :tagNames)", countQuery = "SELECT COUNT(DISTINCT e) " +
-	// 				"FROM EventModel e " +
-	// 				"LEFT JOIN e.status s " +
-	// 				"LEFT JOIN e.faculty f " +
-	// 				"LEFT JOIN e.tags t " +
-	// 				"LEFT JOIN ParticipantEventModel p " +
-	// 				"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
-	// 				"WHERE (:statusId IS NULL OR s.id = :statusId) " +
-	// 				"AND (:facultyId IS NULL OR f.id = :facultyId) " +
-	// 				"AND (:title IS NULL OR e.title LIKE %:title%) " +
-	// 				"AND (CASE " +
-	// 				"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
-	// 				"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
-	// 				"       ELSE true " +
-	// 				"   END) " +
-	// 				"AND s.id != 4 " +
-	// 				"AND (:tagNames IS NULL OR t.name IN :tagNames)")
 	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
 			"FROM EventModel e " +
 			"LEFT JOIN e.status s " +

--- a/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
@@ -13,25 +13,59 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.event.dto.IEventDto;
+import hcmus.alumni.event.dto.IEventListDto;
 import hcmus.alumni.event.model.EventModel;
 
 public interface EventRepository extends JpaRepository<EventModel, String> {
-    @Query(value = "select distinct p.name from role_permission rp " +
+	@Query(value = "select distinct p.name from role_permission rp " +
 			"join permission p on p.id = rp.permission_id and p.is_delete = false " +
 			"join role r on r.id = rp.role_id and r.is_delete = false " +
 			"where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
-    List<String> getPermissions(String userId, String domain);
-	
+	List<String> getPermissions(String userId, String domain);
+
+	// @Query(value = "SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
+	// 		"FROM EventModel e " +
+	// 		"LEFT JOIN e.status s " +
+	// 		"LEFT JOIN e.faculty f " +
+	// 		"LEFT JOIN e.tags t " +
+	// 		"LEFT JOIN ParticipantEventModel p " +
+	// 		"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
+	// 		"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+	// 		"AND (:facultyId IS NULL OR f.id = :facultyId) " +
+	// 		"AND (:title IS NULL OR e.title LIKE %:title%) " +
+	// 		"AND (CASE " +
+	// 		"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
+	// 		"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
+	// 		"       ELSE true " +
+	// 		"   END) " +
+	// 		"AND s.id != 4 " +
+	// 		"AND (:tagNames IS NULL OR t.name IN :tagNames)", countQuery = "SELECT COUNT(DISTINCT e) " +
+	// 				"FROM EventModel e " +
+	// 				"LEFT JOIN e.status s " +
+	// 				"LEFT JOIN e.faculty f " +
+	// 				"LEFT JOIN e.tags t " +
+	// 				"LEFT JOIN ParticipantEventModel p " +
+	// 				"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
+	// 				"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+	// 				"AND (:facultyId IS NULL OR f.id = :facultyId) " +
+	// 				"AND (:title IS NULL OR e.title LIKE %:title%) " +
+	// 				"AND (CASE " +
+	// 				"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
+	// 				"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
+	// 				"       ELSE true " +
+	// 				"   END) " +
+	// 				"AND s.id != 4 " +
+	// 				"AND (:tagNames IS NULL OR t.name IN :tagNames)")
 	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
 			"FROM EventModel e " +
 			"LEFT JOIN e.status s " +
 			"LEFT JOIN e.faculty f " +
 			"LEFT JOIN e.tags t " +
-			"LEFT JOIN ParticipantEventModel p " + 
-			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " + 
+			"LEFT JOIN ParticipantEventModel p " +
+			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
 			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
 			"AND (:facultyId IS NULL OR f.id = :facultyId) " +
-			"AND e.title LIKE %:title% " +
+			"AND (:title IS NULL OR e.title LIKE %:title%) " +
 			"AND (CASE " +
 			"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
 			"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
@@ -39,7 +73,7 @@ public interface EventRepository extends JpaRepository<EventModel, String> {
 			"   END) " +
 			"AND s.id != 4 " +
 			"AND (:tagNames IS NULL OR t.name IN :tagNames)")
-	Page<IEventDto> searchEvents(
+	Page<IEventListDto> searchEvents(
 			@Param("userId") String userId,
 			@Param("title") String title,
 			@Param("statusId") Integer statusId,
@@ -48,57 +82,57 @@ public interface EventRepository extends JpaRepository<EventModel, String> {
 			@Param("startDate") Date startDate,
 			@Param("mode") Integer mode,
 			Pageable pageable);
-	
+
 	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
 			"FROM EventModel e " +
-			"LEFT JOIN ParticipantEventModel p " + 
-			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " + 
+			"LEFT JOIN ParticipantEventModel p " +
+			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
 			"WHERE e.id = :id")
 	Optional<IEventDto> findEventById(String id, @Param("userId") String userId);
 
-    @Transactional
-    @Modifying
-    @Query("UPDATE EventModel e SET e.views = e.views + 1 WHERE e.id = :id")
-    int incrementEventViews(String id);
+	@Transactional
+	@Modifying
+	@Query("UPDATE EventModel e SET e.views = e.views + 1 WHERE e.id = :id")
+	int incrementEventViews(String id);
 
-    @Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " + 
-			"FROM EventModel e " + 
-			"JOIN e.status s " + 
-			"LEFT JOIN ParticipantEventModel p " + 
-			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " + 
+	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
+			"FROM EventModel e " +
+			"JOIN e.status s " +
+			"LEFT JOIN ParticipantEventModel p " +
+			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
 			"WHERE s.id = 2 AND e.organizationTime >= :startDate")
-    Page<IEventDto> getHotEvents(
+	Page<IEventListDto> getHotEvents(
 			@Param("userId") String userId,
 			Date startDate,
 			Pageable pageable);
-    
-	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN requestingParticipant IS NOT NULL THEN true ELSE false END) " + 
-			"FROM EventModel e " + 
-			"LEFT JOIN ParticipantEventModel requestedParticipant " + 
-			"ON requestedParticipant.id.eventId = e.id AND requestedParticipant.isDelete = false " + 
-			"LEFT JOIN ParticipantEventModel requestingParticipant " + 
-			"ON requestingParticipant.id.eventId = e.id " + 
-			"AND requestingParticipant.id.userId = :requestingUserId AND requestingParticipant.isDelete = false " + 
-			"WHERE requestedParticipant.id.userId = :requestedUserId " + 
+
+	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN requestingParticipant IS NOT NULL THEN true ELSE false END) " +
+			"FROM EventModel e " +
+			"LEFT JOIN ParticipantEventModel requestedParticipant " +
+			"ON requestedParticipant.id.eventId = e.id AND requestedParticipant.isDelete = false " +
+			"LEFT JOIN ParticipantEventModel requestingParticipant " +
+			"ON requestingParticipant.id.eventId = e.id " +
+			"AND requestingParticipant.id.userId = :requestingUserId AND requestingParticipant.isDelete = false " +
+			"WHERE requestedParticipant.id.userId = :requestedUserId " +
 			"AND (CASE " +
 			"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
 			"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
 			"       ELSE true " +
 			"   END)")
-	Page<IEventDto> getUserParticipatedEvents(
+	Page<IEventListDto> getUserParticipatedEvents(
 			@Param("requestingUserId") String requestingUserId,
 			@Param("requestedUserId") String requestedUserId,
 			@Param("startDate") Date startDate,
 			@Param("mode") Integer mode,
 			Pageable pageable);
-    
-    @Transactional
+
+	@Transactional
 	@Modifying
 	@Query("UPDATE EventModel n SET n.participants = n.participants + :count WHERE n.id = :id")
-	int participantCountIncrement(String id,@Param("count") Integer count);
-    
-    @Transactional
+	int participantCountIncrement(String id, @Param("count") Integer count);
+
+	@Transactional
 	@Modifying
 	@Query("UPDATE EventModel n SET n.childrenCommentNumber = n.childrenCommentNumber + :count WHERE n.id = :id")
-	int commentCountIncrement(String id,@Param("count") Integer count);
+	int commentCountIncrement(String id, @Param("count") Integer count);
 }

--- a/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/EventRepository.java
@@ -52,6 +52,32 @@ public interface EventRepository extends JpaRepository<EventModel, String> {
 
 	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
 			"FROM EventModel e " +
+			"LEFT JOIN e.status s " +
+			"LEFT JOIN e.faculty f " +
+			"LEFT JOIN e.tags t " +
+			"LEFT JOIN ParticipantEventModel p " +
+			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
+			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+			"AND (f.id = (SELECT u.facultyId FROM UserModel u WHERE u.id = :userId) OR f.id IS NULL) " +
+			"AND (:title IS NULL OR e.title LIKE %:title%) " +
+			"AND (CASE " +
+			"       WHEN :mode = 1 THEN e.organizationTime >= :startDate " +
+			"       WHEN :mode = 2 THEN e.organizationTime < :startDate " +
+			"       ELSE true " +
+			"   END) " +
+			"AND s.id != 4 " +
+			"AND (:tagNames IS NULL OR t.name IN :tagNames)")
+	Page<IEventListDto> searchEventsByUserFaculty(
+			@Param("userId") String userId,
+			@Param("title") String title,
+			@Param("statusId") Integer statusId,
+			@Param("tagNames") List<String> tagNames,
+			@Param("startDate") Date startDate,
+			@Param("mode") Integer mode,
+			Pageable pageable);
+
+	@Query("SELECT DISTINCT new EventModel(e, CASE WHEN p IS NOT NULL THEN true ELSE false END) " +
+			"FROM EventModel e " +
 			"LEFT JOIN ParticipantEventModel p " +
 			"ON p.id.eventId = e.id AND p.id.userId = :userId AND p.isDelete = false " +
 			"WHERE e.id = :id")

--- a/event-service/src/main/java/hcmus/alumni/event/repository/UserRepository.java
+++ b/event-service/src/main/java/hcmus/alumni/event/repository/UserRepository.java
@@ -1,7 +1,14 @@
 package hcmus.alumni.event.repository;
 
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import hcmus.alumni.event.model.UserModel;
 
-public interface UserRepository extends JpaRepository<UserModel, String> {}
+public interface UserRepository extends JpaRepository<UserModel, String> {
+    @Query(value = "SELECT ur.role_id FROM user_role ur " +
+            "WHERE ur.user_id = :userId", nativeQuery = true)
+    Set<Integer> getRoleIds(String userId);
+}

--- a/group-service/Dockerfile
+++ b/group-service/Dockerfile
@@ -24,4 +24,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/group-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/group-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/group-service.jar"]

--- a/hall-of-fame-service/Dockerfile
+++ b/hall-of-fame-service/Dockerfile
@@ -22,4 +22,4 @@ ENV GCP_SERVICE_ACCOUNT_KEY_PATH=/app/gcp-key.json
 COPY --from=builder app/target/hall-of-fame-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/hall-of-fame-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/hall-of-fame-service.jar"]

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/common/FetchHofMode.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/common/FetchHofMode.java
@@ -1,0 +1,5 @@
+package hcmus.alumni.halloffame.common;
+
+public enum FetchHofMode {
+    NORMAL, MANAGEMENT
+}

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/config/StringToEnumConverter.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/config/StringToEnumConverter.java
@@ -1,0 +1,16 @@
+package hcmus.alumni.halloffame.config;
+
+import org.springframework.core.convert.converter.Converter;
+
+import hcmus.alumni.halloffame.common.FetchHofMode;
+
+public class StringToEnumConverter implements Converter<String, FetchHofMode> {
+    @Override
+    public FetchHofMode convert(String source) {
+        try {
+            return FetchHofMode.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return FetchHofMode.NORMAL;
+        }
+    }
+}

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/config/WebConfig.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/config/WebConfig.java
@@ -1,0 +1,13 @@
+package hcmus.alumni.halloffame.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToEnumConverter());
+    }
+}

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/controller/HallOfFameServiceController.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/controller/HallOfFameServiceController.java
@@ -94,9 +94,7 @@ public class HallOfFameServiceController {
 			if (fetchMode.equals(FetchHofMode.MANAGEMENT)) {
 				// Check if is Admin or FacultyManager
 				Set<Integer> roleIds = userRepository.getRoleIds(userId);
-				if (roleIds.contains(ADMIN_ROLE_ID)) {
-					hof = halloffameRepository.searchHof(title, statusId, null, beginningYear, pageable);
-				} else if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
+				if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
 					hof = halloffameRepository.searchHofByUserFaculty(userId, title, statusId, beginningYear, pageable);
 				}
 			}

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/controller/HallOfFameServiceController.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/controller/HallOfFameServiceController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import hcmus.alumni.halloffame.dto.IHallOfFameDto;
+import hcmus.alumni.halloffame.dto.IHallOfFameListDto;
 import hcmus.alumni.halloffame.exception.AppException;
 import hcmus.alumni.halloffame.model.FacultyModel;
 import hcmus.alumni.halloffame.model.HallOfFameModel;
@@ -74,11 +75,14 @@ public class HallOfFameServiceController {
 		if (pageSize <= 0 || pageSize > 50) {
 			pageSize = 50;
 		}
+		if (title.isBlank()) {
+			title = null;
+		}
 		HashMap<String, Object> result = new HashMap<String, Object>();
 
 		try {
 			Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(order), orderBy));
-			Page<IHallOfFameDto> hof = null;
+			Page<IHallOfFameListDto> hof = null;
 
 			hof = halloffameRepository.searchHof(title, statusId, facultyId, beginningYear, pageable);
 
@@ -258,7 +262,7 @@ public class HallOfFameServiceController {
 	@GetMapping("/rand")
 	public ResponseEntity<HashMap<String, Object>> getRandomHof(
 			@RequestParam(value = "number", defaultValue = "8") Integer number) {
-		List<IHallOfFameDto> optionalHallOfFame = halloffameRepository.findRandomHofEntries(number);
+		List<IHallOfFameListDto> optionalHallOfFame = halloffameRepository.findRandomHofEntries(number);
 
 		HashMap<String, Object> result = new HashMap<String, Object>();
 		result.put("hof", optionalHallOfFame);

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/dto/IHallOfFameListDto.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/dto/IHallOfFameListDto.java
@@ -1,0 +1,40 @@
+package hcmus.alumni.halloffame.dto;
+
+import java.util.Date;
+
+public interface IHallOfFameListDto {
+    interface User {
+        String getId(); // Added
+        String getFullName();
+    }
+    interface LinkedUser {
+        String getId();
+        String getFullName();
+        String getEmail();
+    }
+
+    interface StatusPost {
+        Integer getId(); // Added
+        String getName();
+    }
+
+    interface Faculty {
+        Integer getId();
+        String getName();
+    }
+
+    String getId();
+    String getTitle();
+    String getSummary();
+    String getThumbnail();
+    Integer getViews();
+    Date getCreateAt(); // Added
+    Date getUpdateAt();
+    Date getPublishedAt();
+    User getCreator();
+    LinkedUser getLinkedUser();
+    Faculty getFaculty();
+    StatusPost getStatus();
+    Integer getBeginningYear();
+    String getPosition();
+}

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/HallOfFameRepository.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/HallOfFameRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.halloffame.dto.IHallOfFameDto;
+import hcmus.alumni.halloffame.dto.IHallOfFameListDto;
 import hcmus.alumni.halloffame.model.HallOfFameModel;
 
 public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, String> {
@@ -20,7 +21,7 @@ public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, Str
 
 	Optional<HallOfFameModel> findById(String id);
 
-	@Query("SELECT DISTINCT h " + 
+	@Query("SELECT h " + 
 		   "FROM HallOfFameModel h " + 
 		   "LEFT JOIN h.status s " + 
 		   "LEFT JOIN h.faculty f " + 
@@ -28,8 +29,8 @@ public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, Str
 		   "AND (:facultyId IS NULL OR f.id = :facultyId) " + 
 		   "AND (:beginningYear IS NULL OR h.beginningYear = :beginningYear) " + 
 		   "AND s.id != 4 " +
-		   "AND h.title LIKE %:title%")
-	Page<IHallOfFameDto> searchHof(String title, Integer statusId,
+		   "AND (:title IS NULL OR h.title LIKE %:title%)")
+	Page<IHallOfFameListDto> searchHof(String title, Integer statusId,
 			Integer facultyId, Integer beginningYear, Pageable pageable);
 
 	@Query("SELECT COUNT(n) FROM HallOfFameModel n JOIN n.status s WHERE s.name = :statusName")
@@ -53,5 +54,5 @@ public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, Str
     List<String> getPermissions(String userId, String domain);
 	
 	@Query("SELECT hof FROM HallOfFameModel hof WHERE hof.status.id = 2 ORDER BY function('RAND') LIMIT :number")
-    List<IHallOfFameDto> findRandomHofEntries(@Param("number") Integer number);
+    List<IHallOfFameListDto> findRandomHofEntries(@Param("number") Integer number);
 }

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/HallOfFameRepository.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/HallOfFameRepository.java
@@ -21,17 +21,29 @@ public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, Str
 
 	Optional<HallOfFameModel> findById(String id);
 
-	@Query("SELECT h " + 
-		   "FROM HallOfFameModel h " + 
-		   "LEFT JOIN h.status s " + 
-		   "LEFT JOIN h.faculty f " + 
-		   "WHERE (:statusId IS NULL OR s.id = :statusId) " + 
-		   "AND (:facultyId IS NULL OR f.id = :facultyId) " + 
-		   "AND (:beginningYear IS NULL OR h.beginningYear = :beginningYear) " + 
-		   "AND s.id != 4 " +
-		   "AND (:title IS NULL OR h.title LIKE %:title%)")
+	@Query("SELECT h " +
+			"FROM HallOfFameModel h " +
+			"LEFT JOIN h.status s " +
+			"LEFT JOIN h.faculty f " +
+			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+			"AND (:facultyId IS NULL OR f.id = :facultyId) " +
+			"AND (:beginningYear IS NULL OR h.beginningYear = :beginningYear) " +
+			"AND s.id != 4 " +
+			"AND (:title IS NULL OR h.title LIKE %:title%)")
 	Page<IHallOfFameListDto> searchHof(String title, Integer statusId,
 			Integer facultyId, Integer beginningYear, Pageable pageable);
+
+	@Query("SELECT h " +
+			"FROM HallOfFameModel h " +
+			"LEFT JOIN h.status s " +
+			"LEFT JOIN h.faculty f " +
+			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+			"AND (f.id = (SELECT u.facultyId FROM UserModel u WHERE u.id = :userId) OR f.id IS NULL) " +
+			"AND (:beginningYear IS NULL OR h.beginningYear = :beginningYear) " +
+			"AND s.id != 4 " +
+			"AND (:title IS NULL OR h.title LIKE %:title%)")
+	Page<IHallOfFameListDto> searchHofByUserFaculty(String userId, String title, Integer statusId,
+			Integer beginningYear, Pageable pageable);
 
 	@Query("SELECT COUNT(n) FROM HallOfFameModel n JOIN n.status s WHERE s.name = :statusName")
 	Long getCountByStatus(@Param("statusName") String statusName);
@@ -46,13 +58,13 @@ public interface HallOfFameRepository extends JpaRepository<HallOfFameModel, Str
 
 	@Query("SELECT n from HallOfFameModel n JOIN n.status s WHERE s.name = \"Chờ\" AND n.publishedAt <= :now")
 	List<HallOfFameModel> getScheduledHof(Date now);
-	
-    @Query(value = "select distinct p.name from role_permission rp " +
-            "join permission p on p.id = rp.permission_id and p.is_delete = false " +
-            "join role r on r.id = rp.role_id and r.is_delete = false " +
-            "where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
-    List<String> getPermissions(String userId, String domain);
-	
+
+	@Query(value = "select distinct p.name from role_permission rp " +
+			"join permission p on p.id = rp.permission_id and p.is_delete = false " +
+			"join role r on r.id = rp.role_id and r.is_delete = false " +
+			"where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
+	List<String> getPermissions(String userId, String domain);
+
 	@Query("SELECT hof FROM HallOfFameModel hof WHERE hof.status.id = 2 ORDER BY function('RAND') LIMIT :number")
-    List<IHallOfFameListDto> findRandomHofEntries(@Param("number") Integer number);
+	List<IHallOfFameListDto> findRandomHofEntries(@Param("number") Integer number);
 }

--- a/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/UserRepository.java
+++ b/hall-of-fame-service/src/main/java/hcmus/alumni/halloffame/repository/UserRepository.java
@@ -1,9 +1,16 @@
 package hcmus.alumni.halloffame.repository;
 
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import hcmus.alumni.halloffame.model.UserModel;
 
 public interface UserRepository extends JpaRepository<UserModel, String> {
     UserModel findByEmail(String email);
+
+    @Query(value = "SELECT ur.role_id FROM user_role ur " +
+            "WHERE ur.user_id = :userId", nativeQuery = true)
+    Set<Integer> getRoleIds(String userId);
 }

--- a/message-service/Dockerfile
+++ b/message-service/Dockerfile
@@ -24,4 +24,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/message-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/message-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/message-service.jar"]

--- a/news-service/Dockerfile
+++ b/news-service/Dockerfile
@@ -24,4 +24,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/news-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/news-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/news-service.jar"]

--- a/news-service/src/main/java/hcmus/alumni/news/common/FetchNewsMode.java
+++ b/news-service/src/main/java/hcmus/alumni/news/common/FetchNewsMode.java
@@ -1,0 +1,5 @@
+package hcmus.alumni.news.common;
+
+public enum FetchNewsMode {
+    NORMAL, MANAGEMENT
+}

--- a/news-service/src/main/java/hcmus/alumni/news/config/StringToEnumConverter.java
+++ b/news-service/src/main/java/hcmus/alumni/news/config/StringToEnumConverter.java
@@ -1,0 +1,16 @@
+package hcmus.alumni.news.config;
+
+import org.springframework.core.convert.converter.Converter;
+
+import hcmus.alumni.news.common.FetchNewsMode;
+
+public class StringToEnumConverter implements Converter<String, FetchNewsMode> {
+    @Override
+    public FetchNewsMode convert(String source) {
+        try {
+            return FetchNewsMode.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return FetchNewsMode.NORMAL;
+        }
+    }
+}

--- a/news-service/src/main/java/hcmus/alumni/news/config/WebConfig.java
+++ b/news-service/src/main/java/hcmus/alumni/news/config/WebConfig.java
@@ -1,0 +1,13 @@
+package hcmus.alumni.news.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToEnumConverter());
+    }
+}

--- a/news-service/src/main/java/hcmus/alumni/news/controller/NewsServiceController.java
+++ b/news-service/src/main/java/hcmus/alumni/news/controller/NewsServiceController.java
@@ -56,6 +56,7 @@ import hcmus.alumni.news.model.notification.StatusNotificationModel;
 import hcmus.alumni.news.dto.CommentNewsDto;
 import hcmus.alumni.news.dto.ICommentNewsDto;
 import hcmus.alumni.news.dto.INewsDto;
+import hcmus.alumni.news.dto.INewsListDto;
 import hcmus.alumni.news.exception.AppException;
 import hcmus.alumni.news.model.CommentNewsModel;
 import hcmus.alumni.news.model.FacultyModel;
@@ -125,6 +126,9 @@ public class NewsServiceController {
 		if (pageSize <= 0 || pageSize > MAXIMUM_PAGES) {
 			pageSize = MAXIMUM_PAGES;
 		}
+		if (title.isBlank()) {
+			title = null;
+		}
 		HashMap<String, Object> result = new HashMap<String, Object>();
 		if (tagNames != null) {
 			for (int i = 0; i < tagNames.size(); i++) {
@@ -134,7 +138,7 @@ public class NewsServiceController {
 
 		try {
 			Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(order), orderBy));
-			Page<INewsDto> news = null;
+			Page<INewsListDto> news = null;
 
 			news = newsRepository.searchNews(title, facultyId, tagNames, statusId, pageable);
 
@@ -360,7 +364,7 @@ public class NewsServiceController {
 		List<Long> tagIds = optionalNews.get().getTags().stream().map(TagModel::getId).collect(Collectors.toList());
 
 		Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "publishedAt"));
-		Page<INewsDto> news = newsRepository.getRelatedNews(id, facultyId, tagIds, pageable);
+		Page<INewsListDto> news = newsRepository.getRelatedNews(id, facultyId, tagIds, pageable);
 
 		HashMap<String, Object> result = new HashMap<String, Object>();
 		result.put("news", news.getContent());
@@ -387,7 +391,7 @@ public class NewsServiceController {
 		Date startDate = cal.getTime();
 
 		Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "views"));
-		Page<INewsDto> news = newsRepository.getHotNews(startDate, endDate, pageable);
+		Page<INewsListDto> news = newsRepository.getHotNews(startDate, endDate, pageable);
 
 		HashMap<String, Object> result = new HashMap<String, Object>();
 		result.put("news", news.getContent());

--- a/news-service/src/main/java/hcmus/alumni/news/controller/NewsServiceController.java
+++ b/news-service/src/main/java/hcmus/alumni/news/controller/NewsServiceController.java
@@ -148,9 +148,7 @@ public class NewsServiceController {
 			if (fetchMode.equals(FetchNewsMode.MANAGEMENT)) {
 				// Check if is Admin or FacultyManager
 				Set<Integer> roleIds = userRepository.getRoleIds(userId);
-				if (roleIds.contains(ADMIN_ROLE_ID)) {
-					news = newsRepository.searchNews(title, null, tagNames, statusId, pageable);
-				} else if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
+				if (roleIds.contains(FACULTY_MANAGER_ROLE_ID)) {
 					news = newsRepository.searchNewsByUserFaculty(userId, title, tagNames, statusId, pageable);
 				}
 			}

--- a/news-service/src/main/java/hcmus/alumni/news/dto/INewsListDto.java
+++ b/news-service/src/main/java/hcmus/alumni/news/dto/INewsListDto.java
@@ -1,0 +1,34 @@
+package hcmus.alumni.news.dto;
+
+import java.util.Date;
+import java.util.Set;
+
+public interface INewsListDto {
+	interface User{
+		String getFullName();
+	}
+	interface StatusPost{
+		String getName();
+	}
+	interface Tag{
+		Integer getId();
+		String getName();
+	}
+	interface Faculty{
+		Integer getId();
+		String getName();
+	}
+	
+	String getId();
+	String getTitle();
+	String getSummary();
+	String getThumbnail();
+	Integer getViews();
+	Integer getChildrenCommentNumber();
+	Date getUpdateAt();
+	Date getPublishedAt();
+	User getCreator();
+	Set<Tag> getTags();
+	Faculty getFaculty();
+	StatusPost getStatus();
+}

--- a/news-service/src/main/java/hcmus/alumni/news/model/NewsModel.java
+++ b/news-service/src/main/java/hcmus/alumni/news/model/NewsModel.java
@@ -22,16 +22,19 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Entity
 @Table(name = "[news]")
 @AllArgsConstructor
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class NewsModel implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	@Id
 	@Column(name = "id", length = 36, nullable = false)
+	@EqualsAndHashCode.Include
 	private String id;
 
 	@ManyToOne

--- a/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
@@ -43,6 +43,28 @@ public interface NewsRepository extends JpaRepository<NewsModel, String> {
 	Page<INewsListDto> searchNews(String title, Integer facultyId, List<String> tagNames, Integer statusId,
 			Pageable pageable);
 
+	@Query(value = "SELECT n " +
+			"FROM NewsModel n " +
+			"LEFT JOIN n.status s " +
+			"LEFT JOIN n.faculty f " +
+			"LEFT JOIN FETCH n.tags t " +
+			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+			"AND (f.id = (SELECT u.facultyId FROM UserModel u WHERE u.id = :userId) OR f.id IS NULL) " +
+			"AND (:tagNames IS NULL OR t.name IN :tagNames) " +
+			"AND s.id != 4 " +
+			"AND (:title IS NULL OR n.title LIKE %:title%)", countQuery = "SELECT COUNT(DISTINCT n) " +
+					"FROM NewsModel n " +
+					"LEFT JOIN n.status s " +
+					"LEFT JOIN n.faculty f " +
+					"LEFT JOIN n.tags t " +
+					"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+					"AND (f.id = (SELECT u.facultyId FROM UserModel u WHERE u.id = :userId) OR f.id IS NULL) " +
+					"AND (:tagNames IS NULL OR t.name IN :tagNames) " +
+					"AND s.id != 4 " +
+					"AND (:title IS NULL OR n.title LIKE %:title%)")
+	Page<INewsListDto> searchNewsByUserFaculty(String userId, String title, List<String> tagNames, Integer statusId,
+			Pageable pageable);
+
 	@Query("SELECT DISTINCT n " +
 			"FROM NewsModel n " +
 			"LEFT JOIN n.faculty f " +

--- a/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import hcmus.alumni.news.dto.INewsDto;
+import hcmus.alumni.news.dto.INewsListDto;
 import hcmus.alumni.news.model.NewsModel;
 
 public interface NewsRepository extends JpaRepository<NewsModel, String> {
@@ -20,17 +21,26 @@ public interface NewsRepository extends JpaRepository<NewsModel, String> {
 
 	Optional<INewsDto> findNewsById(String id);
 
-	@Query("SELECT DISTINCT n " +
+	@Query(value = "SELECT n " +
 			"FROM NewsModel n " +
 			"LEFT JOIN n.status s " +
 			"LEFT JOIN n.faculty f " +
-			"LEFT JOIN n.tags t " +
+			"LEFT JOIN FETCH n.tags t " +
 			"WHERE (:statusId IS NULL OR s.id = :statusId) " +
 			"AND (:facultyId IS NULL OR f.id = :facultyId) " +
 			"AND (:tagNames IS NULL OR t.name IN :tagNames) " +
 			"AND s.id != 4 " +
-			"AND n.title LIKE %:title%")
-	Page<INewsDto> searchNews(String title, Integer facultyId, List<String> tagNames, Integer statusId,
+			"AND (:title IS NULL OR n.title LIKE %:title%)", countQuery = "SELECT COUNT(DISTINCT n) " +
+					"FROM NewsModel n " +
+					"LEFT JOIN n.status s " +
+					"LEFT JOIN n.faculty f " +
+					"LEFT JOIN n.tags t " +
+					"WHERE (:statusId IS NULL OR s.id = :statusId) " +
+					"AND (:facultyId IS NULL OR f.id = :facultyId) " +
+					"AND (:tagNames IS NULL OR t.name IN :tagNames) " +
+					"AND s.id != 4 " +
+					"AND (:title IS NULL OR n.title LIKE %:title%)")
+	Page<INewsListDto> searchNews(String title, Integer facultyId, List<String> tagNames, Integer statusId,
 			Pageable pageable);
 
 	@Query("SELECT DISTINCT n " +
@@ -41,13 +51,13 @@ public interface NewsRepository extends JpaRepository<NewsModel, String> {
 			"OR (t.id IN :tagsId)) " +
 			"AND n.status.id = 2 " +
 			"AND n.id != :originalNewsId")
-	Page<INewsDto> getRelatedNews(String originalNewsId, Integer facultyId, List<Long> tagsId, Pageable pageable);
+	Page<INewsListDto> getRelatedNews(String originalNewsId, Integer facultyId, List<Long> tagsId, Pageable pageable);
 
 	@Query("SELECT n FROM NewsModel n JOIN n.status s WHERE s.id = 2")
-	Page<INewsDto> getMostViewdNews(Pageable pageable);
+	Page<INewsListDto> getMostViewdNews(Pageable pageable);
 
 	@Query("SELECT n FROM NewsModel n JOIN n.status s WHERE s.id = 2 AND n.publishedAt >= :startDate AND n.publishedAt <= :endDate")
-	Page<INewsDto> getHotNews(Date startDate, Date endDate, Pageable pageable);
+	Page<INewsListDto> getHotNews(Date startDate, Date endDate, Pageable pageable);
 
 	@Query("SELECT COUNT(n) FROM NewsModel n JOIN n.status s WHERE s.id = :statusId")
 	Long getCountByStatusId(@Param("statusId") Integer statusId);
@@ -68,9 +78,9 @@ public interface NewsRepository extends JpaRepository<NewsModel, String> {
 	@Query("UPDATE NewsModel n SET n.childrenCommentNumber = n.childrenCommentNumber + :count WHERE n.id = :id")
 	int commentCountIncrement(String id, @Param("count") Integer count);
 
-    @Query(value = "select distinct p.name from role_permission rp " +
-            "join permission p on p.id = rp.permission_id and p.is_delete = false " +
-            "join role r on r.id = rp.role_id and r.is_delete = false " +
-            "where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
-    List<String> getPermissions(String userId, String domain);
+	@Query(value = "select distinct p.name from role_permission rp " +
+			"join permission p on p.id = rp.permission_id and p.is_delete = false " +
+			"join role r on r.id = rp.role_id and r.is_delete = false " +
+			"where r.id in (select role_id from user_role where user_id = :userId) and p.name like :domain% and rp.is_delete = false;", nativeQuery = true)
+	List<String> getPermissions(String userId, String domain);
 }

--- a/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/NewsRepository.java
@@ -53,9 +53,6 @@ public interface NewsRepository extends JpaRepository<NewsModel, String> {
 			"AND n.id != :originalNewsId")
 	Page<INewsListDto> getRelatedNews(String originalNewsId, Integer facultyId, List<Long> tagsId, Pageable pageable);
 
-	@Query("SELECT n FROM NewsModel n JOIN n.status s WHERE s.id = 2")
-	Page<INewsListDto> getMostViewdNews(Pageable pageable);
-
 	@Query("SELECT n FROM NewsModel n JOIN n.status s WHERE s.id = 2 AND n.publishedAt >= :startDate AND n.publishedAt <= :endDate")
 	Page<INewsListDto> getHotNews(Date startDate, Date endDate, Pageable pageable);
 

--- a/news-service/src/main/java/hcmus/alumni/news/repository/UserRepository.java
+++ b/news-service/src/main/java/hcmus/alumni/news/repository/UserRepository.java
@@ -1,7 +1,14 @@
 package hcmus.alumni.news.repository;
 
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import hcmus.alumni.news.model.UserModel;
 
-public interface UserRepository extends JpaRepository<UserModel, String> {}
+public interface UserRepository extends JpaRepository<UserModel, String> {
+    @Query(value = "SELECT ur.role_id FROM user_role ur " +
+            "WHERE ur.user_id = :userId", nativeQuery = true)
+    Set<Integer> getRoleIds(String userId);
+}

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /app
 COPY --from=builder app/target/notification-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/notification-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/notification-service.jar"]

--- a/service-discovery/Dockerfile
+++ b/service-discovery/Dockerfile
@@ -19,4 +19,4 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 COPY --from=builder app/target/service-discovery.jar /app/
 # Command to run the Java application
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "/app/service-discovery.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "/app/service-discovery.jar"]

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -23,4 +23,4 @@ ENV FCM_SERVICE_ACCOUNT_KEY_PATH=/app/fcm-key.json
 COPY --from=builder app/target/user-service.jar /app/
 # Command to run the Java application
 # Set JVM memory limits based on Heroku's plan
-CMD ["java", "-Xmx200M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/user-service.jar"]
+CMD ["java", "-Xmx150M", "-Xms100M", "-XX:+UseContainerSupport", "-jar", "-Dspring.profiles.active=heroku", "/app/user-service.jar"]

--- a/user-service/src/main/java/hcmus/alumni/userservice/controller/AuthController.java
+++ b/user-service/src/main/java/hcmus/alumni/userservice/controller/AuthController.java
@@ -73,11 +73,11 @@ public class AuthController {
 
 			Set<RoleModel> roles = user.getRoles();
 			List<Integer> roleIds = roles.stream().map(RoleModel::getId).collect(Collectors.toList());
-
 			List<String> permissionNames = permissionRepository.getPermissionNamesByRoleIds(roleIds);
 
 			Map<String, Object> response = new HashMap<>();
 			response.put("jwt", jwtUtils.generateToken(user));
+			response.put("roleIds", roleIds);
 			response.put("permissions", permissionNames);
 
 			return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/user-service/src/main/java/hcmus/alumni/userservice/repository/UserRepository.java
+++ b/user-service/src/main/java/hcmus/alumni/userservice/repository/UserRepository.java
@@ -3,6 +3,7 @@ package hcmus.alumni.userservice.repository;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -117,4 +118,12 @@ public interface UserRepository extends JpaRepository<UserModel, String> {
 	@Modifying
 	@Query("UPDATE UserModel u SET u.lastLogin = :lastLogin WHERE u.email = :email")
 	int setLastLogin(@Param("email") String email, @Param("lastLogin") Date lastLogin);
+
+	@Query(value = "SELECT ur.role_id FROM user_role ur " +
+			"WHERE ur.user_id = :userId", nativeQuery = true)
+	Set<Integer> getRoleIds(String userId);
+
+	@Query(value = "SELECT u.faculty_id FROM user u " +
+			"WHERE u.id = :userId", nativeQuery = true)
+	Integer getFacultyId(String userId);
 }

--- a/user-service/src/main/java/hcmus/alumni/userservice/utils/JwtUtils.java
+++ b/user-service/src/main/java/hcmus/alumni/userservice/utils/JwtUtils.java
@@ -2,6 +2,8 @@ package hcmus.alumni.userservice.utils;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -24,7 +26,6 @@ public class JwtUtils {
 	private long expirationTime; // 3 days
 
 	public boolean validateToken(final String token) {
-		Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
 		try {
 			Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
 			return true;
@@ -41,7 +42,11 @@ public class JwtUtils {
 	}
 
 	public String generateToken(UserModel user) {
-		return Jwts.builder().setSubject(user.getId())
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("fullName", user.getFullName());
+		claims.put("roles", user.getRolesName());
+
+		return Jwts.builder().setClaims(claims).setSubject(user.getId())
 				.setIssuedAt(new Date(System.currentTimeMillis()))
 				.setExpiration(new Date(System.currentTimeMillis() + expirationTime))
 				.signWith(getSignKey(), SignatureAlgorithm.HS256).compact();

--- a/user-service/src/main/java/hcmus/alumni/userservice/utils/JwtUtils.java
+++ b/user-service/src/main/java/hcmus/alumni/userservice/utils/JwtUtils.java
@@ -2,9 +2,8 @@ package hcmus.alumni.userservice.utils;
 
 import java.security.Key;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import hcmus.alumni.userservice.model.UserModel;
@@ -19,8 +18,10 @@ import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtUtils {
-	public static final String SECRET = "givepraiseforhehasnoequalworshiphimagodhasbeenbornuntotheworldcowerinfearhewillnotforgiveanyvicedevoteyourselfyourfateisoverwritten";
-	private final long expirationTime = 259200000L; // 3 days
+	@Value("${jwt.secret}")
+	private String SECRET;
+	@Value("${jwt.expiration}")
+	private long expirationTime; // 3 days
 
 	public boolean validateToken(final String token) {
 		Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
@@ -40,11 +41,7 @@ public class JwtUtils {
 	}
 
 	public String generateToken(UserModel user) {
-		Map<String, Object> claims = new HashMap<>();
-		claims.put("fullName", user.getFullName());
-		claims.put("roles", user.getRolesName());
-
-		return Jwts.builder().setClaims(claims).setSubject(user.getId())
+		return Jwts.builder().setSubject(user.getId())
 				.setIssuedAt(new Date(System.currentTimeMillis()))
 				.setExpiration(new Date(System.currentTimeMillis() + expirationTime))
 				.signWith(getSignKey(), SignatureAlgorithm.HS256).compact();

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -10,3 +10,5 @@ gcp.serviceAccountKeyPath=${GCP_SERVICE_ACCOUNT_KEY_PATH:../gcp-key.json}
 gcp.bucketName=hcmus-alumverse
 gcp.domainName=https://storage.googleapis.com/
 firebase.service.account.path=${GCP_SERVICE_ACCOUNT_KEY_PATH:../fcm-key.json}
+jwt.secret=${JWT_SECRET:givepraiseforhehasnoequalworshiphimagodhasbeenbornuntotheworldcowerinfearhewillnotforgiveanyvicedevoteyourselfyourfateisoverwritten}
+jwt.expiration=${JWT_EXPIRATION:259200000}


### PR DESCRIPTION
Các API lấy danh sách của news, event, và hof không còn trả về trường `content` nữa

Cái chỉnh lại quản lý của khoa nào vẫn coi được thông tin của khoa đó thì t vẫn giữ nguyên mấy cái role cũ. Áp dụng cho các API lấy danh sách news, event, hof, và alumni verification
- Nếu user có role FacultyManager thì khi fetch dữ liệu sẽ chỉ trả về những news, event, hof, và alumni verification dựa theo khoa của user đó
- Nếu FacultyManager có khoa là cntt thì sẽ chỉ lấy những data có khoa cntt hoặc trường khoa là null
- Nếu FacultyManager có trường khoa là null thì chỉ lấy dc data có trường khoa là null
- Admin ko bị ảnh hưởng bởi điều chỉnh này, tức vẫn lấy toàn bộ

Đăng nhập bây giờ trả về thêm `id` của `role`

Chỉnh sửa dữ liệu của role:
- Viết thêm trường `description` cho các `role`
- Điều chỉnh tên 1 số role. `Alumni` -> `VerifiedAlumni`. `Guest` -> `UnverifiedAlumni`